### PR TITLE
Fix "length of undefined" error when delta has no content property

### DIFF
--- a/src/instrumentation/openai/patch.ts
+++ b/src/instrumentation/openai/patch.ts
@@ -246,7 +246,7 @@ async function * handleStreamResponse (
         model = chunk.model
       }
       // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
-      const content = chunk.choices[0]?.delta?.content
+      const content = chunk.choices[0]?.delta?.content || ''
       const tokenCount = estimateTokens(content as string)
       completionTokens += tokenCount
       result.push(content as string)


### PR DESCRIPTION
# Description

Fix the "length of undefined" error when delta has no `content` property, e.g. sometimes at the beginning of the event stream: `{"role": "assistant"}` .

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Backwards compatible
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code