### PR TITLE
Update license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "changeset_version": "changeset version"
   },
   "author": "Scale3 Labs",
-  "license": "AGPL-3.0-or-later",
+  "license": "Apache-2.0",
   "dependencies": {
     "@langtrase/trace-attributes": "^3.0.8",
     "@opentelemetry/api": "^1.7.0",


### PR DESCRIPTION
# Description

Sets the license in package.json to Apache-2.0 instead of AGPL, in accordance with `LICENSE`. (Our CI has a license check, and AGPL is not allowed).

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] Backwards compatible
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have made corresponding changes to the documentation (If applicable)
