### PR TITLE
add vertexai and gemini to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,44 +28,47 @@ To use the managed SaaS version of Langtrace, follow the steps below:
 
 Get started by adding simply three lines to your code!
 
-``` typescript
+```typescript
 npm i @langtrase/typescript-sdk
 ```
 
-``` typescript
+```typescript
 import * as Langtrace from '@langtrase/typescript-sdk' // Must precede any llm module imports
 Langtrace.init({ api_key: <your_api_key> })
 ```
 
 OR
 
-``` typescript
-import * as Langtrace from '@langtrase/typescript-sdk' // Must precede any llm module imports
-LangTrace.init() // LANGTRACE_API_KEY as an ENVIRONMENT variable
+```typescript
+import * as Langtrace from '@langtrase/typescript-sdk'; // Must precede any llm module imports
+LangTrace.init(); // LANGTRACE_API_KEY as an ENVIRONMENT variable
 ```
 
 ## Langtrace Self Hosted
 
 Get started by adding simply two lines to your code and see traces being logged to the console!
 
-``` typescript
+```typescript
 npm i @langtrase/typescript-sdk
 ```
 
-``` typescript
-import * as Langtrace from '@langtrase/typescript-sdk' // Must precede any llm module imports
-Langtrace.init({ write_spans_to_console: true, api_host: '<HOSTED_URL>/api/trace'})
+```typescript
+import * as Langtrace from '@langtrase/typescript-sdk'; // Must precede any llm module imports
+Langtrace.init({
+  write_spans_to_console: true,
+  api_host: '<HOSTED_URL>/api/trace',
+});
 ```
 
 ## Langtrace self hosted custom exporter
 
 Get started by adding simply three lines to your code and see traces being exported to your remote location!
 
-``` typescript
+```typescript
 npm i @langtrase/typescript-sdk
 ```
 
-``` typescript
+```typescript
 import * as Langtrace from '@langtrase/typescript-sdk' // Must precede any llm module imports
 Langtrace.init({ custom_remote_exporter: <your_exporter>, batch:<true or false>})
 ```
@@ -74,24 +77,24 @@ Langtrace.init({ custom_remote_exporter: <your_exporter>, batch:<true or false>}
 
 - [withLangTraceRootSpan](https://docs.langtrace.ai/features/grouptraces) - this function is designed to organize and relate different spans, in a hierarchical manner. When you're performing multiple operations that you want to monitor together as a unit, this function helps by establishing a "parent" (`LangtraceRootSpan` or whatever is passed to `name`) span. Then, any calls to the LLM APIs made within the given function (fn) will be considered "children" of this parent span. This setup is especially useful for tracking the performance or behavior of a group of operations collectively, rather than individually. See [example](https://docs.langtrace.ai/features/grouptraces)
 
-``` typescript
- /**
+```typescript
+/**
  * @param fn  The function to be executed within the context of the root span. The function should accept the spanId and traceId as arguments
  * @param name Name of the root span
  * @param spanAttributes Attributes to be added to the root span
  * @param spanKind The kind of span to be created
  * @returns result of the function
  */
-export async function withLangTraceRootSpan<T> (
+export async function withLangTraceRootSpan<T>(
   fn: (spanId: string, traceId: string) => Promise<T>,
   name = 'LangtraceRootSpan',
   spanKind: SpanKind = SpanKind.INTERNAL
-): Promise<T>
+): Promise<T>;
 ```
 
 - [withAdditionalAttributes](https://docs.langtrace.ai/features/additional_attributes) - this function is designed to enhance the traces by adding custom attributes to the current context. These custom attributes provide extra details about the operations being performed, making it easier to analyze and understand their behavior. See [example](https://docs.langtrace.ai/features/additional_attributes)
 
-``` typescript
+```typescript
 /**
  *
  * @param fn function to be executed within the context with the custom attributes added to the current context
@@ -99,7 +102,10 @@ export async function withLangTraceRootSpan<T> (
  * Attributes can also be an awaited Promise<Record<string, any>>. E.g withAdditionalAttributes(()=>{// Do something}, await getAdditionalAttributes()) // Assuming you have a function called getAdditionalAttributes defined in your code
  * @returns result of the function
  */
-export async function withAdditionalAttributes <T> (fn: () => Promise<T>, attributes: Record<string, any> | Promise<Record<string, any>>): Promise<T>
+export async function withAdditionalAttributes<T>(
+  fn: () => Promise<T>,
+  attributes: Record<string, any> | Promise<Record<string, any>>
+): Promise<T>;
 ```
 
 - [getPromptFromRegistry](https://docs.langtrace.ai/features/manage_prompts) - Fetches either the latest prompt from the prompt registry or a specific version passed in through `options`. See [example](https://docs.langtrace.ai/features/manage_prompts)
@@ -119,7 +125,7 @@ export const getPromptFromRegistry = async (promptRegistryId: string, options?: 
 
 - [sendUserFeedback](https://docs.langtrace.ai/features/traceuserfeedback) - Allows submission of feedback on a users LLM interaction. This function must be used in tandem with the `withLangtraceRootSpan` function. See [example](https://docs.langtrace.ai/features/traceuserfeedback)
 
-``` typescript
+```typescript
 /**
  *
  * @param userId id of the user giving feedback
@@ -143,18 +149,19 @@ Langtrace automatically captures traces from the following vendors:
 | Cohere       | LLM             | :white_check_mark: | :white_check_mark:              |
 | Groq         | LLM             | :x:                | :white_check_mark:              |
 | Perplexity   | LLM             | :white_check_mark: | :white_check_mark:              |
+| Gemini       | LLM             | :x:                | :white_check_mark:              |
 | Langchain    | Framework       | :x:                | :white_check_mark:              |
 | LlamaIndex   | Framework       | :white_check_mark: | :white_check_mark:              |
 | Langgraph    | Framework       | :x:                | :white_check_mark:              |
 | DSPy         | Framework       | :x:                | :white_check_mark:              |
 | CrewAI       | Framework       | :x:                | :white_check_mark:              |
 | Ollama       | Framework       | :x:                | :white_check_mark:              |
+| VertexAI     | Framework       | :x:                | :white_check_mark:              |
 | Pinecone     | Vector Database | :white_check_mark: | :white_check_mark:              |
 | ChromaDB     | Vector Database | :white_check_mark: | :white_check_mark:              |
 | QDrant       | Vector Database | :white_check_mark: | :white_check_mark:              |
 | Weaviate     | Vector Database | :white_check_mark: | :white_check_mark:              |
 | PGVector     | Vector Database | :white_check_mark: | :white_check_mark: (SQLAlchemy) |
-
 
 ## Feature Requests and Issues
 


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue to help is review the PR better and faster.

# Checklist for adding new integration:

- [ ] Defined `APIS` in constants [folder](../src/constants/instrumentation/).
- [ ] Updated `SERVICE_PROVIDERS` in [common.ts](../src/constants/common.ts)
- [ ] Created a folder under [instrumentation](../src/instrumentation/) with the name of the integration with atleast `patch.ts` and `instrumentation.ts` files.
- [ ] Added instrumentation in `allInstrumentations` in [init.ts](../src/init/init.ts) and to the `InstrumentationType` in [types.ts](../src/init/types.ts) files.
- [ ] Added examples for the new integration in the [examples](../src/examples/) folder.
- [ ] Updated [package.json](../package.json) to install new dependencies for devDependencies.
- [ ] Updated the [README.md](../README.md) of [langtrace-typescript-sdk](https://github.com/Scale3-Labs/langtrace-typescript-sdk) to include the new integration in the supported integrations table.
- [ ] Updated the [README.md](https://github.com/Scale3-Labs/langtrace?tab=readme-ov-file#supported-integrations) of Langtrace's [repository](https://github.com/Scale3-Labs/langtrace) to include the new integration in the supported integrations table.
- [ ] Added new integration page to supported integrations in [Langtrace Docs](https://github.com/Scale3-Labs/langtrace-docs)
