### PR TITLE
Bug fix for chroma, pinecone and qdrant failing to instrument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @langtrase/typescript-sdk
 
+## 4.0.1
+
+### Patch Changes
+
+- Fix bug causing qdrant, pinecone and chroma instrumentation to fail
+
 ## 4.0.0
 
 ### Major Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@langtrase/typescript-sdk",
-  "version": "3.3.3",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@langtrase/typescript-sdk",
-      "version": "3.3.3",
+      "version": "4.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@langtrase/trace-attributes": "6.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langtrase/typescript-sdk",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "A typescript SDK for Langtrace",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/instrumentation/chroma/instrumentation.ts
+++ b/src/instrumentation/chroma/instrumentation.ts
@@ -58,7 +58,7 @@ class ChromaInstrumentation extends InstrumentationBase<any> {
       })
     }
 
-    Object.keys(APIS).forEach((api) => {
+    Object.keys(APIS.chromadb).forEach((api) => {
       this._wrap(
         chromadb.Collection.prototype,
         APIS.chromadb[api as keyof typeof APIS.chromadb].OPERATION,
@@ -69,7 +69,7 @@ class ChromaInstrumentation extends InstrumentationBase<any> {
   }
 
   private _unpatch (chromadb: any): void {
-    Object.keys(APIS).forEach((api) => {
+    Object.keys(APIS.chromadb).forEach((api) => {
       this._unwrap(chromadb.Collection.prototype, APIS.chromadb[api as keyof typeof APIS.chromadb].OPERATION as string)
     })
   }

--- a/src/instrumentation/pinecone/instrumentation.ts
+++ b/src/instrumentation/pinecone/instrumentation.ts
@@ -52,12 +52,12 @@ class PineconeInstrumentation extends InstrumentationBase<any> {
 
   private _patch (pinecone: any, moduleVersion?: string): void {
     if (isWrapped(pinecone.Index.prototype)) {
-      Object.keys(APIS).forEach((api) => {
+      Object.keys(APIS.pinecone).forEach((api) => {
         this._unwrap(pinecone.Index.prototype, APIS.pinecone[api as keyof typeof APIS.pinecone].OPERATION as string)
       })
     }
 
-    Object.keys(APIS).forEach((api) => {
+    Object.keys(APIS.pinecone).forEach((api) => {
       this._wrap(
         pinecone.Index.prototype,
         APIS.pinecone[api as keyof typeof APIS.pinecone].OPERATION,
@@ -68,7 +68,7 @@ class PineconeInstrumentation extends InstrumentationBase<any> {
   }
 
   private _unpatch (pinecone: any): void {
-    Object.keys(APIS).forEach((api) => {
+    Object.keys(APIS.pinecone).forEach((api) => {
       this._unwrap(pinecone.Index.prototype, APIS.pinecone[api as keyof typeof APIS.pinecone].OPERATION as string)
     })
   }

--- a/src/instrumentation/qdrant/instrumentation.ts
+++ b/src/instrumentation/qdrant/instrumentation.ts
@@ -53,11 +53,11 @@ class QdrantInstrumentation extends InstrumentationBase<any> {
 
   private _patch (qdrant: any, moduleVersion?: string): void {
     if (isWrapped(qdrant.QdrantClient.prototype)) {
-      Object.keys(APIS).forEach((api) => {
+      Object.keys(APIS.qdrant).forEach((api) => {
         this._unwrap(qdrant.QdrantClient.prototype, APIS.qdrant[api as keyof typeof APIS.qdrant].OPERATION as string)
       })
     }
-    Object.keys(APIS).forEach((api) => {
+    Object.keys(APIS.qdrant).forEach((api) => {
       this._wrap(
         qdrant.QdrantClient.prototype,
         APIS.qdrant[api as keyof typeof APIS.qdrant].OPERATION,
@@ -68,7 +68,7 @@ class QdrantInstrumentation extends InstrumentationBase<any> {
   }
 
   private _unpatch (qdrant: any): void {
-    Object.keys(APIS).forEach((api) => {
+    Object.keys(APIS.qdrant).forEach((api) => {
       this._unwrap(qdrant.QdrantClient.prototype, APIS.qdrant[api as keyof typeof APIS.qdrant].OPERATION as string)
     })
   }


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue to help is review the PR better and faster.

# Checklist for adding new integration:

- [ ] Defined `APIS` in constants [folder](../src/constants/instrumentation/).
- [ ] Updated `SERVICE_PROVIDERS` in [common.ts](../src/constants/common.ts)
- [ ] Created a folder under [instrumentation](../src/instrumentation/) with the name of the integration with atleast `patch.ts` and `instrumentation.ts` files.
- [ ] Added instrumentation in `allInstrumentations` in [init.ts](../src/init/init.ts) and to the `InstrumentationType` in [types.ts](../src/init/types.ts) files.
- [ ] Added examples for the new integration in the [examples](../src/examples/) folder.
- [ ] Updated [package.json](../package.json) to install new dependencies for devDependencies.
- [ ] Updated the [README.md](../README.md) of [langtrace-typescript-sdk](https://github.com/Scale3-Labs/langtrace-typescript-sdk) to include the new integration in the supported integrations table.
- [ ] Updated the [README.md](https://github.com/Scale3-Labs/langtrace?tab=readme-ov-file#supported-integrations) of Langtrace's [repository](https://github.com/Scale3-Labs/langtrace) to include the new integration in the supported integrations table.
- [ ] Added new integration page to supported integrations in [Langtrace Docs](https://github.com/Scale3-Labs/langtrace-docs)
