### PR TITLE
Rohit/s3 en 2715 Add service_name option when tracing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @langtrase/typescript-sdk
 
+## 5.0.3
+
+### Patch Changes
+
+- Add service_name option and support for otel env var
+
 ## 5.0.2
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langtrase/typescript-sdk",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "A typescript SDK for Langtrace",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/init/init.ts
+++ b/src/init/init.ts
@@ -16,6 +16,7 @@
 
 import { getCurrentAndLatestVersion, boxText } from '@langtrace-utils/misc'
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node'
+import { Resource } from '@opentelemetry/resources'
 import { InstrumentationBase, registerInstrumentations } from '@opentelemetry/instrumentation'
 import { ConsoleSpanExporter, BatchSpanProcessor, SimpleSpanProcessor } from '@opentelemetry/sdk-trace-base'
 import { LangTraceExporter } from '@langtrace-extensions/langtraceexporter/langtrace_exporter'
@@ -69,6 +70,7 @@ let isLatestSdk = false
 
 export const init: LangTraceInit = ({
   api_key = undefined,
+  service_name = undefined,
   batch = false,
   write_spans_to_console = false,
   custom_remote_exporter = undefined,
@@ -84,7 +86,11 @@ export const init: LangTraceInit = ({
   disable_tracing_for_functions = undefined,
   disable_tracing_attributes = []
 }: LangtraceInitOptions = {}) => {
-  const provider = new NodeTracerProvider({ sampler: new LangtraceSampler(disable_tracing_for_functions) })
+  const provider = new NodeTracerProvider({
+    sampler: new LangtraceSampler(disable_tracing_for_functions),
+    resource: new Resource({ 'service.name': process.env.OTEL_SERVICE_NAME ?? service_name ?? __filename ?? 'unknown' })
+  }
+  )
   const host = (process.env.LANGTRACE_API_HOST ?? api_host ?? LANGTRACE_REMOTE_URL)
   const remoteWriteExporter = new LangTraceExporter(api_key ?? process.env.LANGTRACE_API_KEY ?? '', host)
   const consoleExporter = new ConsoleSpanExporter()

--- a/src/init/types.ts
+++ b/src/init/types.ts
@@ -34,6 +34,7 @@ export interface LangtraceInitOptions {
     logger?: DiagLogger
     disable?: boolean
   }
+  service_name?: string
   disable_latest_version_check?: boolean
   disable_tracing_for_functions?: Partial<VendorTracedFunctions>
   instrumentations?: { [key in Vendor]?: any }


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue to help is review the PR better and faster.
 Docs update pr 
 https://github.com/Scale3-Labs/langtrace-docs/pull/83
# Checklist for adding new integration:

- [ ] Defined `APIS` in constants [folder](../src/constants/instrumentation/).
- [ ] Updated `SERVICE_PROVIDERS` in [common.ts](../src/constants/common.ts)
- [ ] Created a folder under [instrumentation](../src/instrumentation/) with the name of the integration with atleast `patch.ts` and `instrumentation.ts` files.
- [ ] Added instrumentation in `allInstrumentations` in [init.ts](../src/init/init.ts) and to the `InstrumentationType` in [types.ts](../src/init/types.ts) files.
- [ ] Added examples for the new integration in the [examples](../src/examples/) folder.
- [ ] Updated [package.json](../package.json) to install new dependencies for devDependencies.
- [ ] Updated the [README.md](../README.md) of [langtrace-typescript-sdk](https://github.com/Scale3-Labs/langtrace-typescript-sdk) to include the new integration in the supported integrations table.
- [ ] Updated the [README.md](https://github.com/Scale3-Labs/langtrace?tab=readme-ov-file#supported-integrations) of Langtrace's [repository](https://github.com/Scale3-Labs/langtrace) to include the new integration in the supported integrations table.
- [ ] Added new integration page to supported integrations in [Langtrace Docs](https://github.com/Scale3-Labs/langtrace-docs)
