### PR TITLE
feat: adding vercel-ai anthropic support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @langtrase/typescript-sdk
 
+## 5.0.5
+
+### Patch Changes
+
+- Added support for Vercel AI Anthropic model.
+
 ## 5.0.4
 
 ### Patch Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@langtrase/typescript-sdk",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@langtrase/typescript-sdk",
-      "version": "5.0.4",
+      "version": "5.0.5",
       "license": "Apache-2.0",
       "dependencies": {
-        "@langtrase/trace-attributes": "7.0.1",
+        "@langtrase/trace-attributes": "7.1.0",
         "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/sdk-trace-base": "^1.22.0",
@@ -2075,9 +2075,10 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
     "node_modules/@langtrase/trace-attributes": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@langtrase/trace-attributes/-/trace-attributes-7.0.1.tgz",
-      "integrity": "sha512-onrF2wvt/1KLRTEZvyAdA69qreaTBcLnMmOUujzdbqdpDXoQzuvrafisxB9pm8gWo2p186qNYpam/XzPmv11mQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@langtrase/trace-attributes/-/trace-attributes-7.1.0.tgz",
+      "integrity": "sha512-GIL5A7XhLDaO5xc8eEm+l2auQIGQBYINBHuVhd6DVh7NIUxxJTQ60fyagcVrEAX9S3Scy/RfihRHOGxJDewRvA==",
+      "license": "MIT",
       "dependencies": {
         "json-schema-to-typescript": "^14.1.0",
         "ncp": "^2.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "tiktoken": "^1.0.15"
       },
       "devDependencies": {
+        "@ai-sdk/anthropic": "^0.0.41",
         "@ai-sdk/openai": "^0.0.34",
         "@anthropic-ai/sdk": "^0.24.3",
         "@changesets/cli": "^2.27.1",
@@ -47,6 +48,60 @@
         "tsc-alias": "^1.8.8",
         "typescript": "^4.9.5",
         "weaviate-ts-client": "^2.2.0"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic": {
+      "version": "0.0.41",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-0.0.41.tgz",
+      "integrity": "sha512-ZGH0Xah9II4jEzDm/z+9G6qf0jC2vWRBURBDTWdQlVUI4COOMd8fmTrqwZrQuAl/y72vYakG5k2AKpJSnY6MeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "0.0.19",
+        "@ai-sdk/provider-utils": "1.0.11"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider": {
+      "version": "0.0.19",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-0.0.19.tgz",
+      "integrity": "sha512-WXyyJ0Fqg0OHzUQ/spem4jRFPq+NkYB8YNTVbSQrE+Rpxtm7DqK1x9MrHtIEhoikCMg9wBOCbm7HuMnfsIR5GA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/anthropic/node_modules/@ai-sdk/provider-utils": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-1.0.11.tgz",
+      "integrity": "sha512-u3BmXKg4MeA5s5eN9bWP4ybGJuOTRC2H0YacMCag5fcZ14S6kfukGE8MzRsGU2wTv6A16zLY0XqVvwcqe13mUA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "0.0.19",
+        "eventsource-parser": "1.1.2",
+        "nanoid": "3.3.6",
+        "secure-json-parse": "2.7.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ai-sdk/openai": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langtrase/typescript-sdk",
-  "version": "5.0.4",
+  "version": "5.0.5",
   "description": "A typescript SDK for Langtrace",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "author": "Scale3 Labs",
   "license": "Apache-2.0",
   "dependencies": {
-    "@langtrase/trace-attributes": "7.0.1",
+    "@langtrase/trace-attributes": "7.1.0",
     "@opentelemetry/api": "^1.7.0",
     "@opentelemetry/instrumentation": "^0.49.1",
     "@opentelemetry/sdk-trace-base": "^1.22.0",
@@ -34,6 +34,7 @@
     "tiktoken": "^1.0.15"
   },
   "devDependencies": {
+    "@ai-sdk/anthropic": "^0.0.41",
     "@ai-sdk/openai": "^0.0.34",
     "@anthropic-ai/sdk": "^0.24.3",
     "@changesets/cli": "^2.27.1",

--- a/src/examples/vercel/anthropic.ts
+++ b/src/examples/vercel/anthropic.ts
@@ -1,0 +1,64 @@
+import { createAnthropic } from '@ai-sdk/anthropic'
+import { init } from '@langtrace-init/init'
+import { z } from 'zod'
+
+import ai from '@langtrace-module-wrappers/ai'
+const anthropic = createAnthropic({ apiKey: process.env.ANTHROPIC_API_KEY })
+
+init({ write_spans_to_console: true, instrumentations: { ai }, batch: false })
+
+export async function basicGenerateTextAnthropic (): Promise<void> {
+  const { text } = await ai.generateText({
+    model: anthropic('claude-3-haiku-20240307'),
+    prompt: 'Say hello 1 time'
+  })
+  console.log(text)
+}
+
+export async function basicStreamTextAnthropic (): Promise<void> {
+  const result = await ai.streamText({
+    model: anthropic('claude-3-haiku-20240307'),
+    prompt: 'Say hi twice.'
+  })
+
+  for await (const message of result.textStream) {
+    process.stdout.write(message as string)
+  }
+}
+
+export async function basicGenerateObjectAnthropic (): Promise<void> {
+  const { object } = await ai.generateObject({
+    model: anthropic('claude-3-haiku-20240307'),
+    schema: z.object({
+      recipe: z.object({
+        name: z.string(),
+        ingredients: z.array(
+          z.object({ name: z.string(), amount: z.string() })
+        ),
+        steps: z.array(z.string())
+      })
+    }),
+    prompt: 'Generate a lasagna recipe.'
+  })
+  console.log(object)
+}
+
+export async function basicStreamObjectAnthropic (): Promise<void> {
+  const { partialObjectStream } = await ai.streamObject({
+    model: anthropic('claude-3-haiku-20240307'),
+    schema: z.object({
+      recipe: z.object({
+        name: z.string(),
+        ingredients: z.array(
+          z.object({ name: z.string(), amount: z.string() })
+        ),
+        steps: z.array(z.string())
+      })
+    }),
+    prompt: 'Say hi twice.'
+  })
+
+  for await (const partialObject of partialObjectStream) {
+    console.log(partialObject)
+  }
+}

--- a/src/instrumentation/vercel/anthropic.ts
+++ b/src/instrumentation/vercel/anthropic.ts
@@ -1,0 +1,390 @@
+import { LANGTRACE_ADDITIONAL_SPAN_ATTRIBUTES_KEY } from '@langtrace-constants/common'
+import {
+  APIS,
+  Event,
+  FrameworkSpanAttributes,
+  LLMSpanAttributes,
+  Vendors
+} from '@langtrase/trace-attributes'
+import {
+  context,
+  Exception, Span, SpanKind,
+  SpanStatusCode,
+  trace,
+  Tracer
+} from '@opentelemetry/api'
+
+import { calculatePromptTokens, estimateTokens } from '@langtrace-utils/llm'
+import { addSpanEvent } from '@langtrace-utils/misc'
+
+export async function generateTextPatchAnthropic (
+  this: any,
+  args: any[],
+  originalMethod: (...args: any[]) => any,
+  method: string,
+  tracer: Tracer,
+  langtraceVersion: string,
+  sdkName: string,
+  version?: string
+): Promise<(...args: any[]) => any> {
+  let url: string
+  if (args[0]?.model?.config?.baseURL !== undefined) {
+    url = args[0]?.model?.config?.baseURL
+  } else {
+    url = this?._client?.baseURL
+  }
+
+  const customAttributes = context.active().getValue(LANGTRACE_ADDITIONAL_SPAN_ATTRIBUTES_KEY) ?? {}
+  const attributes: FrameworkSpanAttributes & LLMSpanAttributes = {
+    'langtrace.sdk.name': sdkName,
+    'langtrace.service.name': Vendors.VERCEL,
+    'langtrace.service.type': 'framework',
+    'langtrace.service.version': version,
+    'gen_ai.operation.name': 'chat',
+    'langtrace.version': langtraceVersion,
+    'gen_ai.request.model': args[0]?.model?.modelId,
+    'url.full': '',
+    'url.path': '',
+    'gen_ai.request.stream': false,
+    'http.max.retries': args[0]?.maxRetries,
+    'gen_ai.request.temperature': args[0]?.temperature,
+    'gen_ai.request.top_p': args[0]?.topP,
+    'gen_ai.user': args[0]?.model?.settings?.user,
+    'gen_ai.request.top_logprobs': args[0]?.model?.settings?.logprobs,
+    'gen_ai.request.logprobs': args[0]?.model?.settings?.logprobs !== undefined,
+    'gen_ai.request.logit_bias': JSON.stringify(
+      args[0]?.model?.settings?.logitBias
+    ),
+    'gen_ai.request.max_tokens': args[0]?.maxTokens,
+    'gen_ai.request.tools': JSON.stringify(args[0]?.tools),
+    ...customAttributes
+  }
+  const span = tracer.startSpan(
+    method,
+    { kind: SpanKind.CLIENT, attributes },
+    context.active()
+  )
+  return await context.with(trace.setSpan(context.active(), span), async () => {
+    try {
+      const resp = await originalMethod.apply(this, args)
+      const responses = JSON.stringify(resp?.responseMessages)
+      span.addEvent(Event.GEN_AI_PROMPT, {
+        'gen_ai.prompt': JSON.stringify([
+          { role: 'user', content: args[0]?.prompt }
+        ])
+      })
+      span.addEvent(Event.GEN_AI_COMPLETION, { 'gen_ai.completion': responses })
+      const responseAttributes: Partial<LLMSpanAttributes> = {
+        'url.full': url,
+        'url.path': APIS.anthropic.MESSAGES_CREATE.ENDPOINT,
+        'gen_ai.usage.input_tokens': resp.usage.promptTokens,
+        'gen_ai.usage.output_tokens': resp.usage.completionTokens
+      }
+
+      span.setAttributes({ ...attributes, ...responseAttributes })
+      span.setStatus({ code: SpanStatusCode.OK })
+      return resp
+    } catch (error: any) {
+      span.recordException(error as Exception)
+      span.setStatus({ code: SpanStatusCode.ERROR })
+      throw error
+    } finally {
+      span.end()
+    }
+  })
+}
+
+export async function streamTextPatchAnthropic (
+  this: any,
+  args: any[],
+  originalMethod: (...args: any[]) => any,
+  method: string,
+  tracer: Tracer,
+  langtraceVersion: string,
+  sdkName: string,
+  version?: string
+): Promise<(...args: any[]) => any> {
+  let url: string
+  if (args[0]?.model?.config?.baseURL !== undefined) {
+    url = args[0]?.model?.config?.baseURL
+  } else {
+    url = this?._client?.baseURL
+  }
+
+  const customAttributes = context.active().getValue(LANGTRACE_ADDITIONAL_SPAN_ATTRIBUTES_KEY) ?? {}
+  const attributes: FrameworkSpanAttributes & LLMSpanAttributes = {
+    'langtrace.sdk.name': sdkName,
+    'langtrace.service.name': Vendors.VERCEL,
+    'langtrace.service.type': 'framework',
+    'gen_ai.operation.name': 'chat',
+    'langtrace.service.version': version,
+    'langtrace.version': langtraceVersion,
+    'gen_ai.request.model': args[0]?.model?.modelId,
+    'url.full': '',
+    'url.path': '',
+    'http.max.retries': args[0]?.maxRetries,
+    'gen_ai.request.stream': true,
+    'gen_ai.request.temperature': args[0]?.temperature,
+    'gen_ai.request.top_p': args[0]?.topP,
+    'gen_ai.user': args[0]?.model?.settings?.user,
+    'gen_ai.request.top_logprobs': args[0]?.model?.settings?.logprobs,
+    'gen_ai.request.logprobs': args[0]?.model?.settings?.logprobs !== undefined,
+    'gen_ai.request.logit_bias': JSON.stringify(
+      args[0]?.model?.settings?.logitBias
+    ),
+    'gen_ai.request.max_tokens': args[0]?.maxTokens,
+    'gen_ai.request.tools': JSON.stringify(args[0]?.tools),
+    ...customAttributes
+  }
+  const spanName = customAttributes['langtrace.span.name' as keyof typeof customAttributes] ?? method
+  const span = tracer.startSpan(
+    spanName,
+    { kind: SpanKind.CLIENT, attributes },
+    context.active()
+  )
+  return await context.with(trace.setSpan(context.active(), span), async () => {
+    try {
+      const resp: any = await originalMethod.apply(this, args)
+      addSpanEvent(span, Event.GEN_AI_PROMPT, { 'gen_ai.prompt': JSON.stringify(args[0]?.prompt) })
+      const responseAttributes: Partial<LLMSpanAttributes> = {
+        'url.full': url,
+        'url.path': APIS.anthropic.MESSAGES_CREATE.ENDPOINT
+      }
+      const proxiedResp = new Proxy(resp, {
+        get (target, prop) {
+          if (prop === 'fullStream' || prop === 'textStream') {
+            const promptContent: string = args[0].prompt
+            const promptTokens = calculatePromptTokens(
+              promptContent,
+              attributes['gen_ai.request.model']
+            )
+            return handleAnthropicStreamResponse(
+              span,
+              target[prop],
+              prop,
+              { ...attributes, ...responseAttributes },
+              promptTokens
+            )
+          }
+          return target[prop]
+        }
+      })
+      return proxiedResp
+    } catch (error: any) {
+      span.recordException(error as Exception)
+      span.setStatus({ code: SpanStatusCode.ERROR })
+      span.end()
+      throw error
+    }
+  })
+}
+
+export async function generateObjectPatchAnthropic (
+  this: any,
+  args: any[],
+  originalMethod: (...args: any[]) => any,
+  method: string,
+  tracer: Tracer,
+  langtraceVersion: string,
+  sdkName: string,
+  version?: string
+): Promise<(...args: any[]) => any> {
+  let url: string
+  if (args[0]?.model?.config?.baseURL !== undefined) {
+    url = args[0]?.model?.config?.baseURL
+  } else {
+    url = this?._client?.baseURL
+  }
+
+  const customAttributes = context.active().getValue(LANGTRACE_ADDITIONAL_SPAN_ATTRIBUTES_KEY) ?? {}
+  const attributes: FrameworkSpanAttributes & LLMSpanAttributes = {
+    'langtrace.sdk.name': sdkName,
+    'langtrace.service.name': Vendors.VERCEL,
+    'langtrace.service.type': 'framework',
+    'langtrace.service.version': version,
+    'gen_ai.operation.name': 'chat',
+    'langtrace.version': langtraceVersion,
+    'gen_ai.request.model': args[0]?.model?.modelId,
+    'url.full': '',
+    'url.path': '',
+    'gen_ai.request.stream': false,
+    'http.max.retries': args[0]?.maxRetries,
+    'gen_ai.request.temperature': args[0]?.temperature,
+    'gen_ai.request.top_p': args[0]?.topP,
+    'gen_ai.user': args[0]?.model?.settings?.user,
+    'gen_ai.request.top_logprobs': args[0]?.model?.settings?.logprobs,
+    'gen_ai.request.logprobs': args[0]?.model?.settings?.logprobs !== undefined,
+    'gen_ai.request.logit_bias': JSON.stringify(
+      args[0]?.model?.settings?.logitBias
+    ),
+    'gen_ai.request.max_tokens': args[0]?.maxTokens,
+    'gen_ai.request.tools': JSON.stringify(args[0]?.tools),
+    ...customAttributes
+  }
+  const span = tracer.startSpan(
+    method,
+    { kind: SpanKind.CLIENT, attributes },
+    context.active()
+  )
+  return await context.with(trace.setSpan(context.active(), span), async () => {
+    try {
+      const resp = await originalMethod.apply(this, args)
+      const responses = JSON.stringify(resp?.object)
+      span.addEvent(Event.GEN_AI_PROMPT, {
+        'gen_ai.prompt': JSON.stringify([
+          { role: 'user', content: args[0]?.prompt }
+        ])
+      })
+      span.addEvent(Event.GEN_AI_COMPLETION, { 'gen_ai.completion': responses })
+      const responseAttributes: Partial<LLMSpanAttributes> = {
+        'url.full': url,
+        'url.path': APIS.anthropic.MESSAGES_CREATE.ENDPOINT,
+        'gen_ai.usage.input_tokens': resp.usage.promptTokens,
+        'gen_ai.usage.output_tokens': resp.usage.completionTokens
+      }
+
+      span.setAttributes({ ...attributes, ...responseAttributes })
+      span.setStatus({ code: SpanStatusCode.OK })
+      return resp
+    } catch (error: any) {
+      span.recordException(error as Exception)
+      span.setStatus({ code: SpanStatusCode.ERROR })
+      throw error
+    } finally {
+      span.end()
+    }
+  })
+}
+
+export async function streamObjectPatchAnthropic (
+  this: any,
+  args: any[],
+  originalMethod: (...args: any[]) => any,
+  method: string,
+  tracer: Tracer,
+  langtraceVersion: string,
+  sdkName: string,
+  version?: string
+): Promise<(...args: any[]) => any> {
+  let url: string
+  if (args[0]?.model?.config?.baseURL !== undefined) {
+    url = args[0]?.model?.config?.baseURL
+  } else {
+    url = this?._client?.baseURL
+  }
+
+  const customAttributes = context.active().getValue(LANGTRACE_ADDITIONAL_SPAN_ATTRIBUTES_KEY) ?? {}
+  const attributes: FrameworkSpanAttributes & LLMSpanAttributes = {
+    'langtrace.sdk.name': sdkName,
+    'langtrace.service.name': Vendors.VERCEL,
+    'langtrace.service.type': 'framework',
+    'gen_ai.operation.name': 'chat',
+    'langtrace.service.version': version,
+    'langtrace.version': langtraceVersion,
+    'gen_ai.request.model': args[0]?.model?.modelId,
+    'url.full': '',
+    'url.path': '',
+    'http.max.retries': args[0]?.maxRetries,
+    'gen_ai.request.stream': true,
+    'gen_ai.request.temperature': args[0]?.temperature,
+    'gen_ai.request.top_p': args[0]?.topP,
+    'gen_ai.user': args[0]?.model?.settings?.user,
+    'gen_ai.request.top_logprobs': args[0]?.model?.settings?.logprobs,
+    'gen_ai.request.logprobs': args[0]?.model?.settings?.logprobs !== undefined,
+    'gen_ai.request.logit_bias': JSON.stringify(
+      args[0]?.model?.settings?.logitBias
+    ),
+    'gen_ai.request.max_tokens': args[0]?.maxTokens,
+    'gen_ai.request.tools': JSON.stringify(args[0]?.tools),
+    ...customAttributes
+  }
+  const spanName = customAttributes['langtrace.span.name' as keyof typeof customAttributes] ?? method
+  const span = tracer.startSpan(
+    spanName,
+    { kind: SpanKind.CLIENT, attributes },
+    context.active()
+  )
+  return await context.with(trace.setSpan(context.active(), span), async () => {
+    try {
+      const resp: any = await originalMethod.apply(this, args)
+      addSpanEvent(span, Event.GEN_AI_PROMPT, { 'gen_ai.prompt': JSON.stringify(args[0]?.prompt) })
+      const responseAttributes: Partial<LLMSpanAttributes> = {
+        'url.full': url,
+        'url.path': APIS.anthropic.MESSAGES_CREATE.ENDPOINT
+      }
+      const proxiedResp = new Proxy(resp, {
+        get (target, prop) {
+          if (prop === 'fullStream' || prop === 'textStream' || prop === 'partialObjectStream') {
+            const promptContent: string = args[0].prompt
+            const promptTokens = calculatePromptTokens(
+              promptContent,
+              attributes['gen_ai.request.model']
+            )
+            return handleAnthropicStreamResponse(
+              span,
+              target[prop],
+              prop,
+              { ...attributes, ...responseAttributes },
+              promptTokens
+            )
+          }
+          return target[prop]
+        }
+      })
+      return proxiedResp
+    } catch (error: any) {
+      span.recordException(error as Exception)
+      span.setStatus({ code: SpanStatusCode.ERROR })
+      span.end()
+      throw error
+    }
+  })
+}
+
+async function * handleAnthropicStreamResponse (
+  span: Span,
+  stream: any,
+  streamType: string,
+  inputAttributes: Partial<LLMSpanAttributes>,
+  promptTokens: number
+): any {
+  const result: string[] = []
+  let completionTokens = 0
+  const customAttributes = context.active().getValue(LANGTRACE_ADDITIONAL_SPAN_ATTRIBUTES_KEY) ?? {}
+  addSpanEvent(span, Event.STREAM_START)
+
+  try {
+    for await (const chunk of stream) {
+      const content: string = chunk.textDelta ?? JSON.stringify(chunk)
+      completionTokens += estimateTokens(content)
+      if (chunk?.type === 'finish') {
+        inputAttributes['gen_ai.usage.output_tokens'] = chunk?.usage?.completionTokens
+        inputAttributes['gen_ai.usage.input_tokens'] = chunk?.usage?.promptTokens
+        inputAttributes['gen_ai.usage.total_tokens'] = chunk?.usage?.totalTokens
+      } else {
+        inputAttributes['gen_ai.usage.output_tokens'] = completionTokens
+        inputAttributes['gen_ai.usage.input_tokens'] = promptTokens
+        inputAttributes['gen_ai.usage.total_tokens'] = promptTokens + completionTokens
+      }
+      if (content !== undefined && content.length > 0) {
+        result.push(content)
+        addSpanEvent(span, Event.GEN_AI_COMPLETION_CHUNK, { 'gen_ai.completion.chunk': JSON.stringify({ role: 'assistant', content }) })
+      }
+      yield chunk
+    }
+    addSpanEvent(span, Event.STREAM_END)
+    if (streamType === 'partialObjectStream') {
+      addSpanEvent(span, Event.GEN_AI_COMPLETION, { 'gen_ai.completion': result.length > 0 ? JSON.stringify([{ role: 'assistant', content: result.at(-1) }]) : undefined })
+    } else {
+      addSpanEvent(span, Event.GEN_AI_COMPLETION, { 'gen_ai.completion': result.length > 0 ? JSON.stringify([{ role: 'assistant', content: result.join('') }]) : undefined })
+    }
+    span.setStatus({ code: SpanStatusCode.OK })
+    span.setAttributes({ ...inputAttributes, ...customAttributes })
+  } catch (error: any) {
+    span.recordException(error as Exception)
+    span.setStatus({ code: SpanStatusCode.ERROR })
+    throw error
+  } finally {
+    span.end()
+  }
+}

--- a/src/instrumentation/vercel/instrumentation.ts
+++ b/src/instrumentation/vercel/instrumentation.ts
@@ -47,6 +47,8 @@ class VercelAIInstrumentation extends InstrumentationBase<any> {
     this._unwrap(module, 'streamText')
     this._unwrap(module, 'embed')
     this._unwrap(module, 'embedMany')
+    this._unwrap(module, 'generateObject')
+    this._unwrap(module, 'streamObject')
   }
 }
 export const vercelAIInstrumentation = new VercelAIInstrumentation()

--- a/src/instrumentation/vercel/instrumentation.ts
+++ b/src/instrumentation/vercel/instrumentation.ts
@@ -1,9 +1,9 @@
 import { diag } from '@opentelemetry/api'
 import { InstrumentationBase, InstrumentationModuleDefinition, InstrumentationNodeModuleDefinition } from '@opentelemetry/instrumentation'
 /* eslint-disable no-restricted-imports */
-import { version, name } from '../../../package.json'
+import { embedPatch, generateTextPatch, streamTextPatch, generateObjectPatch, streamObjectPatch } from '@langtrace-instrumentation/vercel/patch'
 import { APIS } from '@langtrase/trace-attributes'
-import { embedPatch, generateTextPatch, streamTextPatch } from '@langtrace-instrumentation/vercel/patch'
+import { name, version } from '../../../package.json'
 
 class VercelAIInstrumentation extends InstrumentationBase<any> {
   constructor () {
@@ -38,6 +38,8 @@ class VercelAIInstrumentation extends InstrumentationBase<any> {
     this._wrap(moduleExports, 'streamText', (original: any) => streamTextPatch.call(this, original as (...args: any[]) => any, APIS.ai.STREAM_TEXT.METHOD, this.tracer, version, name, moduleVersion))
     this._wrap(moduleExports, 'embed', (original: any) => embedPatch.call(this, original as (...args: any[]) => any, APIS.ai.EMBED.METHOD, this.tracer, version, name, moduleVersion))
     this._wrap(moduleExports, 'embedMany', (original: any) => embedPatch.call(this, original as (...args: any[]) => any, APIS.ai.EMBED_MANY.METHOD, this.tracer, version, name, moduleVersion))
+    this._wrap(moduleExports, 'generateObject', (original: any) => generateObjectPatch.call(this, original as (...args: any[]) => any, APIS.ai.GENERATE_OBJECT.METHOD, this.tracer, version, name, moduleVersion))
+    this._wrap(moduleExports, 'streamObject', (original: any) => streamObjectPatch.call(this, original as (...args: any[]) => any, APIS.ai.STREAM_OBJECT.METHOD, this.tracer, version, name, moduleVersion))
   }
 
   public _unpatch (module: any): void {

--- a/src/instrumentation/vercel/patch.ts
+++ b/src/instrumentation/vercel/patch.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-this-alias */
+import { embedPatchOpenAI, generateTextPatchOpenAI, streamTextPatchOpenAI } from '@langtrace-instrumentation/vercel/openai'
+import { generateTextPatchAnthropic, streamTextPatchAnthropic, generateObjectPatchAnthropic, streamObjectPatchAnthropic } from '@langtrace-instrumentation/vercel/anthropic'
 import { Vendors } from '@langtrase/trace-attributes'
 import { Tracer } from '@opentelemetry/api'
-import { embedPatchOpenAI, generateTextPatchOpenAI, streamTextPatchOpenAI } from '@langtrace-instrumentation/vercel/openai'
 
 export function generateTextPatch (
   this: any,
@@ -16,6 +17,9 @@ export function generateTextPatch (
   return async function (this: any, ...args: any[]): Promise<any> {
     if (args[0]?.model?.config?.provider?.includes(Vendors.OPENAI) === true) {
       return await generateTextPatchOpenAI.call(this, patchThis, args, originalMethod, method, tracer, langtraceVersion, sdkName, version)
+    }
+    if (args[0]?.model?.config?.provider?.includes(Vendors.ANTHROPIC) === true) {
+      return await generateTextPatchAnthropic.call(this, args, originalMethod, method, tracer, langtraceVersion, sdkName, version)
     }
     const result = originalMethod.apply(this, args)
     if (result instanceof Promise) {
@@ -60,6 +64,51 @@ export function streamTextPatch (
   return async function (this: any, ...args: any[]): Promise<any> {
     if (args[0]?.model?.config?.provider?.includes(Vendors.OPENAI) === true) {
       return await streamTextPatchOpenAI.call(this, patchThis, args, originalMethod, method, tracer, langtraceVersion, sdkName, version)
+    }
+    if (args[0]?.model?.config?.provider?.includes(Vendors.ANTHROPIC) === true) {
+      return await streamTextPatchAnthropic.call(this, args, originalMethod, method, tracer, langtraceVersion, sdkName, version)
+    }
+    const result = originalMethod.apply(this, args)
+    if (result instanceof Promise) {
+      return await result
+    }
+    return result
+  }
+}
+
+export function generateObjectPatch (
+  this: any,
+  originalMethod: (...args: any[]) => any,
+  method: string,
+  tracer: Tracer,
+  langtraceVersion: string,
+  sdkName: string,
+  version?: string
+): (...args: any[]) => any {
+  return async function (this: any, ...args: any[]): Promise<any> {
+    if (args[0]?.model?.config?.provider?.includes(Vendors.ANTHROPIC) === true) {
+      return await generateObjectPatchAnthropic.call(this, args, originalMethod, method, tracer, langtraceVersion, sdkName, version)
+    }
+    const result = originalMethod.apply(this, args)
+    if (result instanceof Promise) {
+      return await result
+    }
+    return result
+  }
+}
+
+export function streamObjectPatch (
+  this: any,
+  originalMethod: (...args: any[]) => any,
+  method: string,
+  tracer: Tracer,
+  langtraceVersion: string,
+  sdkName: string,
+  version?: string
+): (...args: any[]) => any {
+  return async function (this: any, ...args: any[]): Promise<any> {
+    if (args[0]?.model?.config?.provider?.includes(Vendors.ANTHROPIC) === true) {
+      return await streamObjectPatchAnthropic.call(this, args, originalMethod, method, tracer, langtraceVersion, sdkName, version)
     }
     const result = originalMethod.apply(this, args)
     if (result instanceof Promise) {


### PR DESCRIPTION
# Description

Adding support for Vercel AI Anthropic methods: 
- GenerateText
- StreamText
- GenerateObject
- StreamObject


# Checklist for adding new integration:

- [ ] Defined `APIS` in constants [folder](../src/constants/instrumentation/).
- [ ] Updated `SERVICE_PROVIDERS` in [common.ts](../src/constants/common.ts)
- [ ] Created a folder under [instrumentation](../src/instrumentation/) with the name of the integration with atleast `patch.ts` and `instrumentation.ts` files.
- [ ] Added instrumentation in `allInstrumentations` in [init.ts](../src/init/init.ts) and to the `InstrumentationType` in [types.ts](../src/init/types.ts) files.
- [ ] Added examples for the new integration in the [examples](../src/examples/) folder.
- [x] Updated [package.json](../package.json) to install new dependencies for devDependencies.
- [ ] Updated the [README.md](../README.md) of [langtrace-typescript-sdk](https://github.com/Scale3-Labs/langtrace-typescript-sdk) to include the new integration in the supported integrations table.
- [ ] Updated the [README.md](https://github.com/Scale3-Labs/langtrace?tab=readme-ov-file#supported-integrations) of Langtrace's [repository](https://github.com/Scale3-Labs/langtrace) to include the new integration in the supported integrations table.
- [ ] Added new integration page to supported integrations in [Langtrace Docs](https://github.com/Scale3-Labs/langtrace-docs)
