### PR TITLE
feat: adding gemini support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@ai-sdk/openai": "^0.0.34",
         "@anthropic-ai/sdk": "^0.24.3",
         "@changesets/cli": "^2.27.1",
+        "@google/generative-ai": "^0.1.3",
         "@opentelemetry/exporter-trace-otlp-http": "^0.52.1",
         "@pinecone-database/pinecone": "^2.0.1",
         "@qdrant/js-client-rest": "^1.9.0",
@@ -1875,6 +1876,16 @@
       "dev": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.1.3.tgz",
+      "integrity": "sha512-Cm4uJX1sKarpm1mje/MiOIinM7zdUUrQp/5/qGPAgznbdd/B9zup5ehT6c1qGqycFcSopTA1J1HpqHS5kJR8hQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@graphql-typed-document-node/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@langtrase/typescript-sdk",
-  "version": "5.1.2",
+  "version": "5.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@langtrase/typescript-sdk",
-      "version": "5.1.2",
+      "version": "5.2.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@langtrase/trace-attributes": "7.1.2",
+        "@langtrase/trace-attributes": "7.2.0",
         "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/sdk-trace-base": "^1.22.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2075,9 +2075,10 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
     "node_modules/@langtrase/trace-attributes": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/@langtrase/trace-attributes/-/trace-attributes-7.1.2.tgz",
-      "integrity": "sha512-Jih/Xm5K+6eXCKtJHwKIefE4oVxt/Xyo6Nf7LWXt6lJ4ixBcuva0turmNUTMnEDMhV8c86L9EDQDVklmhh/POw==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@langtrase/trace-attributes/-/trace-attributes-7.2.0.tgz",
+      "integrity": "sha512-F8bwBaCZ94PUTqMpOGFtYg+9B7GF5EoyN8w99hudSr1UXvoG11QQblt4Caw+mqb/4s2lnuJ0xQbQESeUf4StMg==",
+      "license": "MIT",
       "dependencies": {
         "js-tiktoken": "^1.0.14",
         "json-schema-to-typescript": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langtrase/typescript-sdk",
-  "version": "5.1.2",
+  "version": "5.2.0",
   "description": "A typescript SDK for Langtrace",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
   "author": "Scale3 Labs",
   "license": "Apache-2.0",
   "dependencies": {
-    "@langtrase/trace-attributes": "7.1.2",
+    "@langtrase/trace-attributes": "7.2.0",
     "@opentelemetry/api": "^1.7.0",
     "@opentelemetry/instrumentation": "^0.49.1",
     "@opentelemetry/sdk-trace-base": "^1.22.0",
@@ -36,6 +36,7 @@
   "devDependencies": {
     "@ai-sdk/anthropic": "^0.0.41",
     "@ai-sdk/openai": "^0.0.34",
+    "@google/generative-ai": "^0.1.3",
     "@anthropic-ai/sdk": "^0.24.3",
     "@changesets/cli": "^2.27.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.52.1",

--- a/src/examples/gemini/basic.ts
+++ b/src/examples/gemini/basic.ts
@@ -1,0 +1,36 @@
+import { init } from '@langtrace-init/init'
+import { GoogleGenerativeAI } from '@google/generative-ai'
+
+import dotenv from 'dotenv'
+dotenv.config()
+init({ batch: false, write_spans_to_console: true })
+
+if (process.env.GEMINI_API_KEY === undefined) {
+  throw new Error('GEMINI_API_KEY is not defined')
+}
+const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY)
+
+export const basicGeminiChat = async (): Promise<void> => {
+  const model = genAI.getGenerativeModel({
+    model: 'gemini-1.5-flash',
+    generationConfig: {
+      candidateCount: 1,
+      maxOutputTokens: 20,
+      temperature: 1.0
+    }
+  })
+  const prompt = 'Say hi twice'
+  const result = await model.generateContent(prompt)
+  console.log(result.response.text())
+}
+
+export const basicGeminiChatStream = async (): Promise<void> => {
+  const model = genAI.getGenerativeModel({ model: 'gemini-1.5-flash' })
+  const prompt = 'say hi 3 times'
+  const result = await model.generateContentStream(prompt)
+
+  for await (const chunk of result.stream) {
+    const chunkText = chunk.text()
+    process.stdout.write(chunkText)
+  }
+}

--- a/src/init/init.ts
+++ b/src/init/init.ts
@@ -26,6 +26,7 @@ import { LANGTRACE_REMOTE_URL } from '@langtrace-constants/exporter/langtrace_ex
 import { anthropicInstrumentation } from '@langtrace-instrumentation/anthropic/instrumentation'
 import { chromaInstrumentation } from '@langtrace-instrumentation/chroma/instrumentation'
 import { cohereInstrumentation } from '@langtrace-instrumentation/cohere/instrumentation'
+import { geminiInstrumentation } from '@langtrace-instrumentation/gemini/instrumentation'
 import { groqInstrumentation } from '@langtrace-instrumentation/groq/instrumentation'
 import { llamaIndexInstrumentation } from '@langtrace-instrumentation/llamaindex/instrumentation'
 import { openAIInstrumentation } from '@langtrace-instrumentation/openai/instrumentation'
@@ -151,6 +152,7 @@ export const init: LangTraceInit = ({
     openai: openAIInstrumentation,
     cohere: cohereInstrumentation,
     anthropic: anthropicInstrumentation,
+    gemini: geminiInstrumentation,
     groq: groqInstrumentation,
     pinecone: pineconeInstrumentation,
     llamaindex: llamaIndexInstrumentation,

--- a/src/instrumentation/gemini/instrumentation.ts
+++ b/src/instrumentation/gemini/instrumentation.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2024 Scale3 Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { generateContentPatch } from '@langtrace-instrumentation/gemini/patch'
+import { diag } from '@opentelemetry/api'
+import { InstrumentationBase, InstrumentationNodeModuleDefinition, isWrapped } from '@opentelemetry/instrumentation'
+// eslint-disable-next-line no-restricted-imports
+import { name, version } from '../../../package.json'
+
+class GeminiInstrumentation extends InstrumentationBase<any> {
+  constructor () {
+    super(name, version)
+  }
+
+  init (): Array<InstrumentationNodeModuleDefinition<any>> {
+    diag.debug('init GeminiInstrumentation')
+    const module = new InstrumentationNodeModuleDefinition<any>(
+      '@google/generative-ai',
+      ['>=0.1.3'],
+      (moduleExports, moduleVersion) => {
+        diag.debug(`Patching Gemini SDK version ${moduleVersion}`)
+        this._patch(moduleExports, moduleVersion as string)
+        return moduleExports
+      },
+      (moduleExports, moduleVersion) => {
+        diag.debug(`Unpatching Gemini SDK version ${moduleVersion}`)
+        if (moduleExports !== undefined) {
+          this._unpatch(moduleExports)
+        }
+      }
+    )
+    return [module]
+  }
+
+  private _patch (gemini: any, moduleVersion?: string): void {
+    if (isWrapped(gemini.GenerativeModel.prototype)) {
+      this._unpatch(gemini)
+    }
+
+    this._wrap(gemini.GenerativeModel.prototype,
+      'generateContent',
+      (originalMethod: (...args: any[]) => any) =>
+        generateContentPatch(originalMethod, this.tracer, this.instrumentationVersion, name, moduleVersion)
+    )
+
+    this._wrap(gemini.GenerativeModel.prototype,
+      'generateContentStream',
+      (originalMethod: (...args: any[]) => any) =>
+        generateContentPatch(originalMethod, this.tracer, this.instrumentationVersion, name, moduleVersion)
+    )
+  }
+
+  private _unpatch (gemini: any): void {
+    this._unwrap(gemini.GoogleGenerativeAI.GenerativeModel, 'generateContent')
+    this._unwrap(gemini.GoogleGenerativeAI.GenerativeModel, 'generateContentStream')
+  }
+}
+
+export const geminiInstrumentation = new GeminiInstrumentation()

--- a/src/instrumentation/gemini/patch.ts
+++ b/src/instrumentation/gemini/patch.ts
@@ -1,0 +1,186 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+/*
+ * Copyright (c) 2024 Scale3 Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LANGTRACE_ADDITIONAL_SPAN_ATTRIBUTES_KEY } from '@langtrace-constants/common'
+import { calculatePromptTokens, estimateTokens } from '@langtrace-utils/llm'
+import { addSpanEvent, createStreamProxy } from '@langtrace-utils/misc'
+import {
+  APIS,
+  Event,
+  LLMSpanAttributes,
+  Vendors
+} from '@langtrase/trace-attributes'
+import {
+  context,
+  diag,
+  Exception,
+  Span,
+  SpanKind,
+  SpanStatusCode,
+  trace,
+  Tracer
+} from '@opentelemetry/api'
+
+export function generateContentPatch (
+  originalMethod: (...args: any[]) => any,
+  tracer: Tracer,
+  langtraceVersion: string,
+  sdkName: string,
+  version?: string
+): (...args: any[]) => any {
+  return async function (this: any, ...args: any[]) {
+    const serviceProvider = Vendors.GEMINI
+    const customAttributes = context.active().getValue(LANGTRACE_ADDITIONAL_SPAN_ATTRIBUTES_KEY) ?? {}
+
+    const prompts = args.map(arg => ({
+      role: 'user',
+      content: arg
+    }))
+
+    const attributes: LLMSpanAttributes = {
+      'langtrace.sdk.name': sdkName,
+      'langtrace.service.name': serviceProvider,
+      'langtrace.service.type': 'llm',
+      'gen_ai.operation.name': 'chat',
+      'langtrace.service.version': version,
+      'langtrace.version': langtraceVersion,
+      'url.full': '',
+      'url.path': '',
+      'gen_ai.request.model': this?.model,
+      'http.max.retries': this?._client?.maxRetries,
+      'http.timeout': this?._client?.timeout,
+      'gen_ai.request.temperature': this?.generationConfig?.temperature,
+      'gen_ai.request.top_p': this?.generationConfig?.topP,
+      'gen_ai.request.top_k': this?.generationConfig?.topK,
+      'gen_ai.request.max_tokens': this?.generationConfig?.maxOutputTokens,
+      'gen_ai.request.response_format': this?.generationConfig?.responseMimeType,
+      'gen_ai.request.frequency_penalty': this?.generationConfig?.frequencyPenalty,
+      'gen_ai.request.presence_penalty': this?.generationConfig?.presencePenalty,
+      'gen_ai.request.seed': this?.generationConfig?.seed,
+      ...customAttributes
+    }
+
+    const spanName = customAttributes['langtrace.span.name' as keyof typeof customAttributes] || APIS.gemini.GENERATE_CONTENT.METHOD
+
+    const span = tracer.startSpan(
+      spanName,
+      { kind: SpanKind.CLIENT, attributes },
+      context.active()
+    )
+    addSpanEvent(span, Event.GEN_AI_PROMPT, { 'gen_ai.prompt': JSON.stringify(prompts) })
+
+    return await context.with(
+      trace.setSpan(context.active(), span),
+      async () => {
+        try {
+          const resp = await originalMethod.apply(this, args)
+          if (Boolean(resp?.stream) && typeof resp?.stream[Symbol.asyncIterator] === 'function') {
+            // Change the span name for streaming
+            span.updateName(APIS.gemini.GENERATE_CONTENT_STREAM.METHOD)
+            const model = this?.model
+            const promptContent: string = JSON.stringify(prompts)
+            const promptTokens = calculatePromptTokens(
+              promptContent,
+              model as string
+            )
+
+            const wrappedStream = createStreamProxy(
+              resp.stream,
+              handleStreamResponse(span, resp.stream, promptTokens, attributes)
+            )
+
+            return {
+              ...resp,
+              stream: wrappedStream
+            }
+          } else {
+            addSpanEvent(span, Event.GEN_AI_COMPLETION, { 'gen_ai.completion': JSON.stringify(resp.response.text()) })
+
+            const respAttributes: Partial<LLMSpanAttributes> = {
+              'gen_ai.usage.input_tokens': Number(
+                resp?.response?.usageMetadata?.promptTokenCount
+              ),
+              'gen_ai.usage.output_tokens': Number(
+                resp?.response?.usageMetadata?.candidatesTokenCount
+              ),
+              'gen_ai.usage.total_tokens': Number(
+                resp?.response?.usageMetadata?.totalTokenCount
+              ),
+              'gen_ai.response.finish_reasons':
+                resp?.response?.candidates[0]?.finishReason
+            }
+            span.setAttributes({ ...attributes, ...respAttributes })
+            span.setStatus({ code: SpanStatusCode.OK })
+            span.end()
+            return resp
+          }
+        } catch (error: any) {
+          span.setStatus({ code: SpanStatusCode.ERROR })
+          span.recordException(error as Exception)
+          throw error
+        }
+      }
+    )
+  }
+}
+
+async function * handleStreamResponse (
+  span: Span,
+  stream: any,
+  promptTokens: number,
+  inputAttributes: Partial<LLMSpanAttributes>
+): AsyncGenerator {
+  let completionTokens = 0
+  const result: string[] = []
+  diag.debug('handleStreamResponse for Gemini')
+  const customAttributes =
+    context.active().getValue(LANGTRACE_ADDITIONAL_SPAN_ATTRIBUTES_KEY) ?? {}
+  addSpanEvent(span, Event.STREAM_START)
+  try {
+    for await (const chunk of stream) {
+      // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+      const content = chunk.text ? chunk.text() : ''
+      const tokenCount = estimateTokens(content as string)
+      completionTokens += tokenCount
+      result.push(content as string)
+      yield chunk
+    }
+    addSpanEvent(span, Event.GEN_AI_COMPLETION, {
+      'gen_ai.completion':
+        result.length > 0
+          ? JSON.stringify([{ role: 'assistant', content: result.join('') }])
+          : undefined
+    })
+
+    const attributes: Partial<LLMSpanAttributes> = {
+      'gen_ai.usage.output_tokens': promptTokens,
+      'gen_ai.usage.input_tokens': completionTokens,
+      'gen_ai.usage.total_tokens': promptTokens + completionTokens,
+      ...customAttributes
+    }
+    span.setAttributes({ ...inputAttributes, ...attributes })
+    span.setStatus({ code: SpanStatusCode.OK })
+    addSpanEvent(span, Event.STREAM_END)
+    return stream
+  } catch (error: any) {
+    span.recordException(error as Exception)
+    span.setStatus({ code: SpanStatusCode.ERROR })
+    throw error
+  } finally {
+    span.end()
+  }
+}


### PR DESCRIPTION
# Description

Introduces Gemini instrumentation for Typescript SDK by adding support for following methods:
- generateContent
- generateContentStream

Release https://github.com/Scale3-Labs/langtrace-trace-attributes/pull/85 before merging this PR

# Checklist for adding new integration:

- [ ] Defined `APIS` in constants [folder](../src/constants/instrumentation/).
- [ ] Updated `SERVICE_PROVIDERS` in [common.ts](../src/constants/common.ts)
- [ ] Created a folder under [instrumentation](../src/instrumentation/) with the name of the integration with atleast `patch.ts` and `instrumentation.ts` files.
- [ ] Added instrumentation in `allInstrumentations` in [init.ts](../src/init/init.ts) and to the `InstrumentationType` in [types.ts](../src/init/types.ts) files.
- [ ] Added examples for the new integration in the [examples](../src/examples/) folder.
- [ ] Updated [package.json](../package.json) to install new dependencies for devDependencies.
- [ ] Updated the [README.md](../README.md) of [langtrace-typescript-sdk](https://github.com/Scale3-Labs/langtrace-typescript-sdk) to include the new integration in the supported integrations table.
- [ ] Updated the [README.md](https://github.com/Scale3-Labs/langtrace?tab=readme-ov-file#supported-integrations) of Langtrace's [repository](https://github.com/Scale3-Labs/langtrace) to include the new integration in the supported integrations table.
- [ ] Added new integration page to supported integrations in [Langtrace Docs](https://github.com/Scale3-Labs/langtrace-docs)
