### PR TITLE
feat: adding vertexai instrumentation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Langtrace automatically captures traces from the following vendors:
 | CrewAI       | Framework       | :x:                | :white_check_mark:              |
 | Ollama       | Framework       | :white_check_mark: | :white_check_mark:              |
 | VertexAI     | Framework       | :white_check_mark: | :white_check_mark:              |
-| VercelAI     | Framework       | :white_check_mark: | :white_check_mark:              |
+| VercelAI     | Framework       | :white_check_mark: | :x:              |
 | Pinecone     | Vector Database | :white_check_mark: | :white_check_mark:              |
 | ChromaDB     | Vector Database | :white_check_mark: | :white_check_mark:              |
 | QDrant       | Vector Database | :white_check_mark: | :white_check_mark:              |

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Langtrace automatically captures traces from the following vendors:
 | Groq         | LLM             | :x:                | :white_check_mark:              |
 | Perplexity   | LLM             | :white_check_mark: | :white_check_mark:              |
 | Gemini       | LLM             | :white_check_mark: | :white_check_mark:              |
+| Mistral      | LLM             | :x:                | :white_check_mark:              |
 | Langchain    | Framework       | :x:                | :white_check_mark:              |
 | LlamaIndex   | Framework       | :white_check_mark: | :white_check_mark:              |
 | Langgraph    | Framework       | :x:                | :white_check_mark:              |
@@ -157,7 +158,7 @@ Langtrace automatically captures traces from the following vendors:
 | CrewAI       | Framework       | :x:                | :white_check_mark:              |
 | Ollama       | Framework       | :white_check_mark: | :white_check_mark:              |
 | VertexAI     | Framework       | :white_check_mark: | :white_check_mark:              |
-| VercelAI     | Framework       | :white_check_mark: | :x:              |
+| VercelAI     | Framework       | :white_check_mark: | :x:                             |
 | Pinecone     | Vector Database | :white_check_mark: | :white_check_mark:              |
 | ChromaDB     | Vector Database | :white_check_mark: | :white_check_mark:              |
 | QDrant       | Vector Database | :white_check_mark: | :white_check_mark:              |

--- a/README.md
+++ b/README.md
@@ -149,15 +149,15 @@ Langtrace automatically captures traces from the following vendors:
 | Cohere       | LLM             | :white_check_mark: | :white_check_mark:              |
 | Groq         | LLM             | :x:                | :white_check_mark:              |
 | Perplexity   | LLM             | :white_check_mark: | :white_check_mark:              |
-| Gemini       | LLM             | :x:                | :white_check_mark:              |
+| Gemini       | LLM             | :white_check_mark: | :white_check_mark:              |
 | Langchain    | Framework       | :x:                | :white_check_mark:              |
 | LlamaIndex   | Framework       | :white_check_mark: | :white_check_mark:              |
 | Langgraph    | Framework       | :x:                | :white_check_mark:              |
 | DSPy         | Framework       | :x:                | :white_check_mark:              |
 | CrewAI       | Framework       | :x:                | :white_check_mark:              |
 | Ollama       | Framework       | :white_check_mark: | :white_check_mark:              |
-| VertexAI     | Framework       | :x:                | :white_check_mark:              |
-| VercelAI     | Framework       | :white_check_mark: | :x:              |
+| VertexAI     | Framework       | :white_check_mark: | :white_check_mark:              |
+| VercelAI     | Framework       | :white_check_mark: | :white_check_mark:              |
 | Pinecone     | Vector Database | :white_check_mark: | :white_check_mark:              |
 | ChromaDB     | Vector Database | :white_check_mark: | :white_check_mark:              |
 | QDrant       | Vector Database | :white_check_mark: | :white_check_mark:              |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@langtrase/typescript-sdk",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@langtrase/typescript-sdk",
-      "version": "5.2.0",
+      "version": "5.3.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@langtrase/trace-attributes": "7.2.0",
+        "@langtrase/trace-attributes": "7.3.0",
         "@opentelemetry/api": "^1.7.0",
         "@opentelemetry/instrumentation": "^0.49.1",
         "@opentelemetry/sdk-trace-base": "^1.22.0",
@@ -26,6 +26,7 @@
         "@ai-sdk/openai": "^0.0.34",
         "@anthropic-ai/sdk": "^0.24.3",
         "@changesets/cli": "^2.27.1",
+        "@google-cloud/vertexai": "^1.5.0",
         "@google/generative-ai": "^0.1.3",
         "@opentelemetry/exporter-trace-otlp-http": "^0.52.1",
         "@pinecone-database/pinecone": "^2.0.1",
@@ -1878,6 +1879,19 @@
         "node": ">=14"
       }
     },
+    "node_modules/@google-cloud/vertexai": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/vertexai/-/vertexai-1.6.0.tgz",
+      "integrity": "sha512-4GUJ0YmEQ9bWmc5f6EdTgSfCGCokhtG6qQyEzwPtSEgDzu3rYzTp8aq5x7MXw6lKIBqNxXqSUXvNIPNdHfmq5Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^9.1.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@google/generative-ai": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.1.3.tgz",
@@ -2086,9 +2100,9 @@
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg=="
     },
     "node_modules/@langtrase/trace-attributes": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@langtrase/trace-attributes/-/trace-attributes-7.2.0.tgz",
-      "integrity": "sha512-F8bwBaCZ94PUTqMpOGFtYg+9B7GF5EoyN8w99hudSr1UXvoG11QQblt4Caw+mqb/4s2lnuJ0xQbQESeUf4StMg==",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/@langtrase/trace-attributes/-/trace-attributes-7.3.0.tgz",
+      "integrity": "sha512-AbBwRT/0RZ36sNZZRLWgV7ELLz537dyO99Uj8m0Nm2ToH58LYLa+ESYaBVv9x7Wro28yUlu/yOi4ZwXjI2L9Qg==",
       "license": "MIT",
       "dependencies": {
         "js-tiktoken": "^1.0.14",
@@ -4168,6 +4182,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.1.tgz",
+      "integrity": "sha512-H0TSyFNDMomMNJQBn8wFV5YC/2eJ+VXECwOadZJT554xP6cODZHPX3H9QMQECxvrgiSOP1pHjy1sMWQVYJOUOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/agentkeepalive": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
@@ -4635,6 +4662,16 @@
         "node": "*"
       }
     },
+    "node_modules/bignumber.js": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -4778,6 +4815,13 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/buffer-from": {
       "version": "1.1.2",
@@ -5592,6 +5636,16 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
       "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.795",
@@ -6627,6 +6681,13 @@
         "type": "^2.7.2"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/extendable-error": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/extendable-error/-/extendable-error-0.1.7.tgz",
@@ -7089,6 +7150,88 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-5.3.0.tgz",
+      "integrity": "sha512-FNTkdNEnBdlqF2oatizolQqNANMrcqJt6AAYt99B3y1aLLC8Hc5IOBb+ZnnzllodEEf6xMBp6wRcBbc16fa65w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "gaxios": "^5.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/gaxios": {
+      "version": "5.1.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-5.1.3.tgz",
+      "integrity": "sha512-95hVgBRgEIRQQQHIbnxBXeHbW4TqFk4ZDJW7wmVtvYar72FdhRIo1UGOLS2eRAKCPEdPBWu+M7+A33D9CdX9rA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^5.0.0",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/gcp-metadata/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -7229,6 +7372,38 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "9.14.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.14.0.tgz",
+      "integrity": "sha512-Y/eq+RWVs55Io/anIsm24sDS8X79Tq948zVLGaa7+KlJYYqaGwp1YI37w48nzrNi12RgnzMrQD4NzdmCowT90g==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-auth-library/node_modules/gcp-metadata": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.0.tgz",
+      "integrity": "sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -7312,6 +7487,20 @@
         "formdata-node": "^4.3.2",
         "node-fetch": "^2.6.7",
         "web-streams-polyfill": "^3.2.1"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/guid-typescript": {
@@ -7430,6 +7619,20 @@
           "url": "https://patreon.com/mdevils"
         }
       ]
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.5.tgz",
+      "integrity": "sha512-1e4Wqeblerz+tMKPIq2EMGiiWW1dIjZOksyHWSUm1rmuvw/how9hBHZ38lAGj5ID4Ik6EdkOw7NmWPy6LAwalw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.0.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/human-id": {
       "version": "1.0.2",
@@ -8025,6 +8228,16 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -8226,6 +8439,29 @@
         "pako": "~1.0.2",
         "readable-stream": "~2.3.6",
         "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -36,10 +36,10 @@
   "devDependencies": {
     "@ai-sdk/anthropic": "^0.0.41",
     "@ai-sdk/openai": "^0.0.34",
-    "@google/generative-ai": "^0.1.3",
     "@anthropic-ai/sdk": "^0.24.3",
     "@changesets/cli": "^2.27.1",
     "@google-cloud/vertexai": "^1.5.0",
+    "@google/generative-ai": "^0.1.3",
     "@opentelemetry/exporter-trace-otlp-http": "^0.52.1",
     "@pinecone-database/pinecone": "^2.0.1",
     "@qdrant/js-client-rest": "^1.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langtrase/typescript-sdk",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "description": "A typescript SDK for Langtrace",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -21,7 +21,7 @@
   "author": "Scale3 Labs",
   "license": "Apache-2.0",
   "dependencies": {
-    "@langtrase/trace-attributes": "7.2.0",
+    "@langtrase/trace-attributes": "7.3.0",
     "@opentelemetry/api": "^1.7.0",
     "@opentelemetry/instrumentation": "^0.49.1",
     "@opentelemetry/sdk-trace-base": "^1.22.0",
@@ -39,6 +39,7 @@
     "@google/generative-ai": "^0.1.3",
     "@anthropic-ai/sdk": "^0.24.3",
     "@changesets/cli": "^2.27.1",
+    "@google-cloud/vertexai": "^1.5.0",
     "@opentelemetry/exporter-trace-otlp-http": "^0.52.1",
     "@pinecone-database/pinecone": "^2.0.1",
     "@qdrant/js-client-rest": "^1.9.0",

--- a/src/examples/vertexai/basic.ts
+++ b/src/examples/vertexai/basic.ts
@@ -1,0 +1,75 @@
+import { init } from '@langtrace-init/init'
+import dotenv from 'dotenv'
+import { VertexAI } from '@google-cloud/vertexai'
+
+dotenv.config()
+init({ batch: false, write_spans_to_console: true })
+
+const project = 'model-palace-429011-f5'
+const location = 'us-central1'
+const textModel = 'gemini-1.5-flash'
+
+const vertexAI = new VertexAI({ project, location })
+
+const generativeModel = vertexAI.getGenerativeModel({ model: textModel })
+
+export const basicVertexAIChat = async (): Promise<void> => {
+  const request = { contents: [{ role: 'user', parts: [{ text: 'How are you doing today?' }] }] }
+  const result = await generativeModel.generateContent(request)
+  const response = result.response
+  console.log('Response: ', JSON.stringify(response))
+}
+
+export const basicVertexAIDirectPromptStream = async (): Promise<void> => {
+  const prompt = 'Write a story about a magic backpack.'
+  const result = await generativeModel.generateContentStream(prompt)
+
+  // Print text as it comes in.
+  for await (const item of result.stream) {
+    console.log('stream chunk: ', JSON.stringify(item))
+  }
+}
+
+export const basicVertexAIChatStream = async (): Promise<void> => {
+  const request = { contents: [{ role: 'user', parts: [{ text: 'How are you doing today?' }] }] }
+  const streamingResult = await generativeModel.generateContentStream(request)
+  for await (const item of streamingResult.stream) {
+    console.log('stream chunk: ', JSON.stringify(item))
+  }
+  const aggregatedResponse = await streamingResult.response
+  console.log('aggregated response: ', JSON.stringify(aggregatedResponse))
+}
+
+export const basicImageVertexAIChat = async (): Promise<void> => {
+  const filePart = { fileData: { fileUri: 'gs://generativeai-downloads/images/scones.jpg', mimeType: 'image/jpeg' } }
+  const textPart = { text: 'What is this picture about?' }
+  const request = { contents: [{ role: 'user', parts: [textPart, filePart] }] }
+  const streamingResult = await generativeModel.generateContentStream(request)
+  for await (const item of streamingResult.stream) {
+    console.log('stream chunk: ', JSON.stringify(item))
+  }
+}
+
+export const basicVertexAIStartChat = async (): Promise<void> => {
+  const chat = generativeModel.startChat()
+  const chatInput = 'How can I learn more about Node.js?'
+  const result = await chat.sendMessage(chatInput)
+  const response = result.response
+  console.log('response: ', JSON.stringify(response))
+}
+
+export const basicVertexAIStartChatStream = async (): Promise<void> => {
+  const chat = generativeModel.startChat();
+  const chatInput = "How can I learn more about Node.js?";
+  const result = await chat.sendMessageStream(chatInput);
+  for await (const item of result.stream) {
+    const text = item.candidates?.[0]?.content?.parts?.[0]?.text;
+    if (text) {
+      console.log("Stream chunk: ", text);
+    } else {
+      console.log("Stream chunk: No text available");
+    }
+  }
+  const aggregatedResponse = await result.response;
+  console.log('Aggregated response: ', JSON.stringify(aggregatedResponse));
+}

--- a/src/examples/vertexai/basic.ts
+++ b/src/examples/vertexai/basic.ts
@@ -59,17 +59,17 @@ export const basicVertexAIStartChat = async (): Promise<void> => {
 }
 
 export const basicVertexAIStartChatStream = async (): Promise<void> => {
-  const chat = generativeModel.startChat();
-  const chatInput = "How can I learn more about Node.js?";
-  const result = await chat.sendMessageStream(chatInput);
+  const chat = generativeModel.startChat()
+  const chatInput = 'How can I learn more about Node.js?'
+  const result = await chat.sendMessageStream(chatInput)
   for await (const item of result.stream) {
-    const text = item.candidates?.[0]?.content?.parts?.[0]?.text;
-    if (text) {
-      console.log("Stream chunk: ", text);
+    const text = item.candidates?.[0]?.content?.parts?.[0]?.text
+    if (text === undefined || text === null) {
+      console.log('Stream chunk: ', text)
     } else {
-      console.log("Stream chunk: No text available");
+      console.log('Stream chunk: No text available')
     }
   }
-  const aggregatedResponse = await result.response;
-  console.log('Aggregated response: ', JSON.stringify(aggregatedResponse));
+  const aggregatedResponse = await result.response
+  console.log('Aggregated response: ', JSON.stringify(aggregatedResponse))
 }

--- a/src/init/init.ts
+++ b/src/init/init.ts
@@ -40,6 +40,8 @@ import { ollamaInstrumentation } from '@langtrace-instrumentation/ollama/instrum
 import { Vendor } from '@langtrase/trace-attributes'
 import { vercelAIInstrumentation } from '@langtrace-instrumentation/vercel/instrumentation'
 import { DropAttributesProcessor } from '@langtrace-extensions/spanprocessors/DropAttributesProcessor'
+import { vertexAIInstrumentation } from '@langtrace-instrumentation/vertexai/instrumentation'
+// import { vertexAIInstrumentation } from '@langtrace-instrumentation/vertexai/instrumentation'
 /**
  * Initializes the LangTrace sdk with custom options.
  *
@@ -161,7 +163,8 @@ export const init: LangTraceInit = ({
     weaviate: weaviateInstrumentation,
     pg: pgInstrumentation,
     ai: vercelAIInstrumentation,
-    ollama: ollamaInstrumentation
+    ollama: ollamaInstrumentation,
+    vertexai: vertexAIInstrumentation
   }
   const initOptions: LangtraceInitOptions = {
     api_key,

--- a/src/init/init.ts
+++ b/src/init/init.ts
@@ -41,7 +41,7 @@ import { Vendor } from '@langtrase/trace-attributes'
 import { vercelAIInstrumentation } from '@langtrace-instrumentation/vercel/instrumentation'
 import { DropAttributesProcessor } from '@langtrace-extensions/spanprocessors/DropAttributesProcessor'
 import { vertexAIInstrumentation } from '@langtrace-instrumentation/vertexai/instrumentation'
-// import { vertexAIInstrumentation } from '@langtrace-instrumentation/vertexai/instrumentation'
+
 /**
  * Initializes the LangTrace sdk with custom options.
  *

--- a/src/instrumentation/gemini/instrumentation.ts
+++ b/src/instrumentation/gemini/instrumentation.ts
@@ -26,7 +26,6 @@ class GeminiInstrumentation extends InstrumentationBase<any> {
   }
 
   init (): Array<InstrumentationNodeModuleDefinition<any>> {
-    diag.debug('init GeminiInstrumentation')
     const module = new InstrumentationNodeModuleDefinition<any>(
       '@google/generative-ai',
       ['>=0.1.3'],

--- a/src/instrumentation/vercel/patch.ts
+++ b/src/instrumentation/vercel/patch.ts
@@ -14,6 +14,7 @@ export function generateTextPatch (
   version?: string
 ): (...args: any[]) => any {
   const patchThis = this
+
   return async function (this: any, ...args: any[]): Promise<any> {
     if (args[0]?.model?.config?.provider?.includes(Vendors.OPENAI) === true) {
       return await generateTextPatchOpenAI.call(this, patchThis, args, originalMethod, method, tracer, langtraceVersion, sdkName, version)

--- a/src/instrumentation/vercel/patch.ts
+++ b/src/instrumentation/vercel/patch.ts
@@ -14,7 +14,6 @@ export function generateTextPatch (
   version?: string
 ): (...args: any[]) => any {
   const patchThis = this
-
   return async function (this: any, ...args: any[]): Promise<any> {
     if (args[0]?.model?.config?.provider?.includes(Vendors.OPENAI) === true) {
       return await generateTextPatchOpenAI.call(this, patchThis, args, originalMethod, method, tracer, langtraceVersion, sdkName, version)
@@ -40,7 +39,6 @@ export function embedPatch (
   version?: string
 ): (...args: any[]) => any {
   const patchThis = this
-
   return async function (this: any, ...args: any[]): Promise<any> {
     if (args[0]?.model?.config?.provider?.includes(Vendors.OPENAI) === true) {
       return await embedPatchOpenAI.call(this, patchThis, args, originalMethod, method, tracer, langtraceVersion, sdkName, version)

--- a/src/instrumentation/vercel/patch.ts
+++ b/src/instrumentation/vercel/patch.ts
@@ -40,6 +40,7 @@ export function embedPatch (
   version?: string
 ): (...args: any[]) => any {
   const patchThis = this
+
   return async function (this: any, ...args: any[]): Promise<any> {
     if (args[0]?.model?.config?.provider?.includes(Vendors.OPENAI) === true) {
       return await embedPatchOpenAI.call(this, patchThis, args, originalMethod, method, tracer, langtraceVersion, sdkName, version)

--- a/src/instrumentation/vertexai/instrumentation.ts
+++ b/src/instrumentation/vertexai/instrumentation.ts
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2024 Scale3 Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { generateContentPatch } from '@langtrace-instrumentation/vertexai/patch'
+import { APIS } from '@langtrase/trace-attributes'
+import { diag } from '@opentelemetry/api'
+import { InstrumentationBase, InstrumentationNodeModuleDefinition, isWrapped } from '@opentelemetry/instrumentation'
+// eslint-disable-next-line no-restricted-imports
+import { name, version } from '../../../package.json'
+
+class VertexAIInstrumentation extends InstrumentationBase<any> {
+  constructor () {
+    super(name, version)
+  }
+
+  init (): Array<InstrumentationNodeModuleDefinition<any>> {
+    const module = new InstrumentationNodeModuleDefinition<any>(
+      '@google-cloud/vertexai',
+      ['>=1.5.0'],
+      (moduleExports, moduleVersion) => {
+        diag.debug(`Patching Vertex AI SDK version ${moduleVersion}`)
+        this._patch(moduleExports, moduleVersion as string)
+        return moduleExports
+      },
+      (moduleExports, moduleVersion) => {
+        diag.debug(`Unpatching Vertex AI SDK version ${moduleVersion}`)
+        if (moduleExports !== undefined) {
+          this._unpatch(moduleExports)
+        }
+      }
+    )
+    return [module]
+  }
+
+  private _patch (vertexai: any, moduleVersion?: string): void {
+    if (isWrapped(vertexai.GenerativeModel.prototype)) {
+      this._unpatch(vertexai)
+    }
+
+    this._wrap(vertexai.GenerativeModel.prototype,
+      'generateContent',
+      (originalMethod: (...args: any[]) => any) =>
+        generateContentPatch(originalMethod, this.tracer, APIS.vertexai.GENERATE_CONTENT.METHOD, this.instrumentationVersion, name, moduleVersion)
+    )
+
+    this._wrap(vertexai.GenerativeModel.prototype,
+      'generateContentStream',
+      (originalMethod: (...args: any[]) => any) =>
+        generateContentPatch(originalMethod, this.tracer, APIS.vertexai.GENERATE_CONTENT_STREAM.METHOD, this.instrumentationVersion, name, moduleVersion)
+    )
+
+    this._wrap(vertexai.ChatSession.prototype,
+      'sendMessage',
+      (originalMethod: (...args: any[]) => any) =>
+        generateContentPatch(originalMethod, this.tracer, APIS.vertexai.SEND_MESSAGE.METHOD, this.instrumentationVersion, name, moduleVersion)
+    )
+
+    this._wrap(vertexai.ChatSession.prototype,
+      'sendMessageStream',
+      (originalMethod: (...args: any[]) => any) =>
+        generateContentPatch(originalMethod, this.tracer, APIS.vertexai.SEND_MESSAGE_STREAM.METHOD, this.instrumentationVersion, name, moduleVersion)
+    )
+  }
+
+  private _unpatch (vertexai: any): void {
+    this._unwrap(vertexai.GoogleGenerativeAI.GenerativeModel, 'generateContent')
+    this._unwrap(vertexai.GoogleGenerativeAI.GenerativeModel, 'generateContentStream')
+    this._unwrap(vertexai.GoogleGenerativeAI.GenerativeModel, 'sendMessage')
+    this._unwrap(vertexai.GoogleGenerativeAI.GenerativeModel, 'sendMessageStream')
+  }
+}
+
+export const vertexAIInstrumentation = new VertexAIInstrumentation()

--- a/src/instrumentation/vertexai/patch.ts
+++ b/src/instrumentation/vertexai/patch.ts
@@ -16,6 +16,13 @@
  */
 
 import { LANGTRACE_ADDITIONAL_SPAN_ATTRIBUTES_KEY } from '@langtrace-constants/common'
+import {
+  Candidate,
+  CandidateContent,
+  CandidateContentPart,
+  Resp,
+  Response
+} from '@langtrace-instrumentation/vertexai/types'
 import { calculatePromptTokens, estimateTokens } from '@langtrace-utils/llm'
 import { addSpanEvent, createStreamProxy } from '@langtrace-utils/misc'
 import {
@@ -33,40 +40,6 @@ import {
   trace,
   Tracer
 } from '@opentelemetry/api'
-
-interface CandidateContentPart {
-  text: string
-}
-
-interface CandidateContent {
-  role: string
-  parts: CandidateContentPart[]
-}
-
-interface Candidate {
-  content: CandidateContent
-  finishReason: string
-  safetyRatings: any[] // You can replace 'any' with a more specific type if needed
-  avgLogprobs: number
-  index: number
-}
-
-interface UsageMetadata {
-  promptTokenCount: number
-  candidatesTokenCount: number
-  totalTokenCount: number
-}
-
-interface Response {
-  text?: any
-  candidates: Candidate[]
-  usageMetadata: UsageMetadata
-}
-
-interface Resp {
-  stream?: any
-  response: Response
-}
 
 export function generateContentPatch (
   originalMethod: (...args: any[]) => any,

--- a/src/instrumentation/vertexai/patch.ts
+++ b/src/instrumentation/vertexai/patch.ts
@@ -1,0 +1,241 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+/*
+ * Copyright (c) 2024 Scale3 Labs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { LANGTRACE_ADDITIONAL_SPAN_ATTRIBUTES_KEY } from '@langtrace-constants/common'
+import { calculatePromptTokens, estimateTokens } from '@langtrace-utils/llm'
+import { addSpanEvent, createStreamProxy } from '@langtrace-utils/misc'
+import {
+  Event,
+  LLMSpanAttributes,
+  Vendors
+} from '@langtrase/trace-attributes'
+import {
+  context,
+  diag,
+  Exception,
+  Span,
+  SpanKind,
+  SpanStatusCode,
+  trace,
+  Tracer
+} from '@opentelemetry/api'
+
+interface CandidateContentPart {
+  text: string
+}
+
+interface CandidateContent {
+  role: string
+  parts: CandidateContentPart[]
+}
+
+interface Candidate {
+  content: CandidateContent
+  finishReason: string
+  safetyRatings: any[] // You can replace 'any' with a more specific type if needed
+  avgLogprobs: number
+  index: number
+}
+
+interface UsageMetadata {
+  promptTokenCount: number
+  candidatesTokenCount: number
+  totalTokenCount: number
+}
+
+interface Response {
+  text?: any
+  candidates: Candidate[]
+  usageMetadata: UsageMetadata
+}
+
+interface Resp {
+  stream?: any
+  response: Response
+}
+
+export function generateContentPatch (
+  originalMethod: (...args: any[]) => any,
+  tracer: Tracer,
+  methodSpanName: string,
+  langtraceVersion: string,
+  sdkName: string,
+  version?: string
+): (...args: any[]) => any {
+  return async function (this: any, ...args: any[]) {
+    const serviceProvider = Vendors.VERTEXAI
+    const customAttributes = context.active().getValue(LANGTRACE_ADDITIONAL_SPAN_ATTRIBUTES_KEY) ?? {}
+
+    const prompts = args.flatMap((arg: string | { contents: CandidateContent[] }) => {
+      if (typeof arg === 'string') {
+        // Handle the case where `arg` is a string
+        return [{ role: 'user', content: arg }]
+      } else {
+        // Handle the case where `arg` has the `contents` structure
+        return arg.contents.map(content => ({
+          role: content.role,
+          content: content.parts.map(part => part.text).join('')
+        }))
+      }
+    })
+
+    const attributes: LLMSpanAttributes = {
+      'langtrace.sdk.name': sdkName,
+      'langtrace.service.name': serviceProvider,
+      'langtrace.service.type': 'llm',
+      'gen_ai.operation.name': 'chat',
+      'langtrace.service.version': version,
+      'langtrace.version': langtraceVersion,
+      'url.full': '',
+      'url.path': this?.publisherModelEndpoint,
+      'gen_ai.request.model': this?.model,
+      'http.max.retries': this?._client?.maxRetries,
+      'http.timeout': this?._client?.timeout,
+      'gen_ai.request.temperature': this?.generationConfig?.temperature,
+      'gen_ai.request.top_p': this?.generationConfig?.topP,
+      'gen_ai.request.top_k': this?.generationConfig?.topK,
+      'gen_ai.request.max_tokens': this?.generationConfig?.maxOutputTokens,
+      'gen_ai.request.response_format': this?.generationConfig?.responseMimeType,
+      'gen_ai.request.frequency_penalty': this?.generationConfig?.frequencyPenalty,
+      'gen_ai.request.presence_penalty': this?.generationConfig?.presencePenalty,
+      'gen_ai.request.seed': this?.generationConfig?.seed,
+      ...customAttributes
+    }
+
+    const spanName = customAttributes['langtrace.span.name' as keyof typeof customAttributes] || methodSpanName
+
+    const span = tracer.startSpan(
+      spanName,
+      { kind: SpanKind.CLIENT, attributes },
+      context.active()
+    )
+    addSpanEvent(span, Event.GEN_AI_PROMPT, { 'gen_ai.prompt': JSON.stringify(prompts) })
+
+    return await context.with(
+      trace.setSpan(context.active(), span),
+      async () => {
+        try {
+          const resp = await originalMethod.apply(this, args) as Resp
+
+          if (Boolean(resp?.stream) && (typeof resp?.stream[Symbol.asyncIterator] === 'function')) {
+            // Change the span name for streaming
+            span.updateName(methodSpanName)
+            const model = this?.model
+            const promptContent: string = JSON.stringify(prompts)
+            const promptTokens = calculatePromptTokens(
+              promptContent,
+              model as string
+            )
+
+            const wrappedStream = createStreamProxy(
+              resp.stream,
+              handleStreamResponse(span, resp.stream, promptTokens, attributes)
+            )
+
+            return {
+              ...resp,
+              stream: wrappedStream
+            }
+          } else {
+            const formattedContent = resp.response.candidates.map((candidate: Candidate) => {
+              return {
+                role: candidate.content.role,
+                content: candidate.content.parts.map((part: CandidateContentPart) => part.text).join(' ')
+              }
+            })
+
+            addSpanEvent(span, Event.GEN_AI_COMPLETION, { 'gen_ai.completion': JSON.stringify(formattedContent) })
+
+            const respAttributes: Partial<LLMSpanAttributes> = {
+              'gen_ai.usage.input_tokens': Number(
+                resp?.response?.usageMetadata?.promptTokenCount
+              ),
+              'gen_ai.usage.output_tokens': Number(
+                resp?.response?.usageMetadata?.candidatesTokenCount
+              ),
+              'gen_ai.usage.total_tokens': Number(
+                resp?.response?.usageMetadata?.totalTokenCount
+              ),
+              'gen_ai.response.finish_reasons':
+                [resp?.response.candidates[0].finishReason],
+              'gen_ai.request.top_logprobs': resp?.response?.candidates[0]?.avgLogprobs
+            }
+            span.setAttributes({ ...attributes, ...respAttributes })
+            span.setStatus({ code: SpanStatusCode.OK })
+            span.end()
+            return resp
+          }
+        } catch (error: any) {
+          span.setStatus({ code: SpanStatusCode.ERROR })
+          span.recordException(error as Exception)
+          throw error
+        }
+      }
+    )
+  }
+}
+
+async function * handleStreamResponse (
+  span: Span,
+  stream: any,
+  promptTokens: number,
+  inputAttributes: Partial<LLMSpanAttributes>
+): AsyncGenerator {
+  let completionTokens = 0
+  const result: string[] = []
+  diag.debug('handleStreamResponse for Vertex')
+  const customAttributes =
+    context.active().getValue(LANGTRACE_ADDITIONAL_SPAN_ATTRIBUTES_KEY) ?? {}
+  addSpanEvent(span, Event.STREAM_START)
+  try {
+    for await (const chunk of stream as Response[]) {
+      const { content } = chunk.candidates.map((candidate: Candidate) => {
+        return {
+          role: candidate.content.role,
+          content: candidate.content.parts.map((part: CandidateContentPart) => part.text).join('')
+        }
+      })[0]
+      const tokenCount = estimateTokens(content)
+      completionTokens += tokenCount
+      result.push(content)
+      yield chunk
+    }
+    addSpanEvent(span, Event.GEN_AI_COMPLETION, {
+      'gen_ai.completion':
+        result.length > 0
+          ? JSON.stringify([{ role: 'model', content: result.join('') }])
+          : undefined
+    })
+
+    const attributes: Partial<LLMSpanAttributes> = {
+      'gen_ai.usage.input_tokens': promptTokens,
+      'gen_ai.usage.output_tokens': completionTokens,
+      'gen_ai.usage.total_tokens': promptTokens + completionTokens,
+      ...customAttributes
+    }
+    span.setAttributes({ ...inputAttributes, ...attributes })
+    span.setStatus({ code: SpanStatusCode.OK })
+    addSpanEvent(span, Event.STREAM_END)
+    return stream
+  } catch (error: any) {
+    span.recordException(error as Exception)
+    span.setStatus({ code: SpanStatusCode.ERROR })
+    throw error
+  } finally {
+    span.end()
+  }
+}

--- a/src/instrumentation/vertexai/types.ts
+++ b/src/instrumentation/vertexai/types.ts
@@ -1,0 +1,33 @@
+export interface CandidateContentPart {
+  text: string
+}
+
+export interface CandidateContent {
+  role: string
+  parts: CandidateContentPart[]
+}
+
+export interface Candidate {
+  content: CandidateContent
+  finishReason: string
+  safetyRatings: any[]
+  avgLogprobs: number
+  index: number
+}
+
+export interface UsageMetadata {
+  promptTokenCount: number
+  candidatesTokenCount: number
+  totalTokenCount: number
+}
+
+export interface Response {
+  text?: any
+  candidates: Candidate[]
+  usageMetadata: UsageMetadata
+}
+
+export interface Resp {
+  stream?: any
+  response: Response
+}


### PR DESCRIPTION
# Description

Adding support for Google Vertex AI instrumentation for methods:
- generateContent
- generateContentStream
- sendMessage
- sendMessageStream

Reference PR for trace-attributes: https://github.com/Scale3-Labs/langtrace-trace-attributes/pull/87

# Checklist for adding new integration:

- [ ] Defined `APIS` in constants [folder](../src/constants/instrumentation/).
- [ ] Updated `SERVICE_PROVIDERS` in [common.ts](../src/constants/common.ts)
- [ ] Created a folder under [instrumentation](../src/instrumentation/) with the name of the integration with atleast `patch.ts` and `instrumentation.ts` files.
- [ ] Added instrumentation in `allInstrumentations` in [init.ts](../src/init/init.ts) and to the `InstrumentationType` in [types.ts](../src/init/types.ts) files.
- [ ] Added examples for the new integration in the [examples](../src/examples/) folder.
- [ ] Updated [package.json](../package.json) to install new dependencies for devDependencies.
- [ ] Updated the [README.md](../README.md) of [langtrace-typescript-sdk](https://github.com/Scale3-Labs/langtrace-typescript-sdk) to include the new integration in the supported integrations table.
- [ ] Updated the [README.md](https://github.com/Scale3-Labs/langtrace?tab=readme-ov-file#supported-integrations) of Langtrace's [repository](https://github.com/Scale3-Labs/langtrace) to include the new integration in the supported integrations table.
- [ ] Added new integration page to supported integrations in [Langtrace Docs](https://github.com/Scale3-Labs/langtrace-docs)
