### PR TITLE
fix: allow manual patch for Gemini and VertexAI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @langtrase/typescript-sdk
 
+## 5.3.1
+
+### Patch Changes
+
+- Fix allowing manual patch for Gemini and Vertex AI.
+
 ## 5.3.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langtrase/typescript-sdk",
-  "version": "5.3.0",
+  "version": "5.3.1",
   "description": "A typescript SDK for Langtrace",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/instrumentation/gemini/instrumentation.ts
+++ b/src/instrumentation/gemini/instrumentation.ts
@@ -25,6 +25,11 @@ class GeminiInstrumentation extends InstrumentationBase<any> {
     super(name, version)
   }
 
+  public manualPatch (gemini: any): void {
+    diag.debug('Manually instrumenting Gemini SDK')
+    this._patch(gemini)
+  }
+
   init (): Array<InstrumentationNodeModuleDefinition<any>> {
     const module = new InstrumentationNodeModuleDefinition<any>(
       '@google/generative-ai',

--- a/src/instrumentation/vertexai/instrumentation.ts
+++ b/src/instrumentation/vertexai/instrumentation.ts
@@ -26,6 +26,11 @@ class VertexAIInstrumentation extends InstrumentationBase<any> {
     super(name, version)
   }
 
+  public manualPatch (vertexai: any): void {
+    diag.debug('Manually instrumenting Vertex AI SDK')
+    this._patch(vertexai)
+  }
+
   init (): Array<InstrumentationNodeModuleDefinition<any>> {
     const module = new InstrumentationNodeModuleDefinition<any>(
       '@google-cloud/vertexai',


### PR DESCRIPTION
# Description

Add manual patch methods for Gemini and Vertex AI

# Checklist for adding new integration:

- [ ] Defined `APIS` in constants [folder](../src/constants/instrumentation/).
- [ ] Updated `SERVICE_PROVIDERS` in [common.ts](../src/constants/common.ts)
- [ ] Created a folder under [instrumentation](../src/instrumentation/) with the name of the integration with atleast `patch.ts` and `instrumentation.ts` files.
- [ ] Added instrumentation in `allInstrumentations` in [init.ts](../src/init/init.ts) and to the `InstrumentationType` in [types.ts](../src/init/types.ts) files.
- [ ] Added examples for the new integration in the [examples](../src/examples/) folder.
- [ ] Updated [package.json](../package.json) to install new dependencies for devDependencies.
- [ ] Updated the [README.md](../README.md) of [langtrace-typescript-sdk](https://github.com/Scale3-Labs/langtrace-typescript-sdk) to include the new integration in the supported integrations table.
- [ ] Updated the [README.md](https://github.com/Scale3-Labs/langtrace?tab=readme-ov-file#supported-integrations) of Langtrace's [repository](https://github.com/Scale3-Labs/langtrace) to include the new integration in the supported integrations table.
- [ ] Added new integration page to supported integrations in [Langtrace Docs](https://github.com/Scale3-Labs/langtrace-docs)
