### PR TITLE
Update ingestion URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langtrase/typescript-sdk",
-  "version": "5.4.0",
+  "version": "6.0.0",
   "description": "A typescript SDK for Langtrace",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/constants/exporter/langtrace_exporter.ts
+++ b/src/constants/exporter/langtrace_exporter.ts
@@ -14,4 +14,4 @@
  * limitations under the License.
  */
 
-export const LANGTRACE_REMOTE_URL = 'https://langtrace.ai'
+export const LANGTRACE_REMOTE_URL = 'https://app.langtrace.ai'

--- a/src/extensions/langtraceexporter/langtrace_exporter.ts
+++ b/src/extensions/langtraceexporter/langtrace_exporter.ts
@@ -28,7 +28,7 @@ export class LangTraceExporter implements SpanExporter {
   /**
    *
    * @param apiKey Your API key. If not set, the value will be read from the LANGTRACE_API_KEY environment variable
-   * @param apiHost The host of the LangTrace API. Default is https://langtrace.ai/api/trace. If set a POST request will be made to this URL with an array of ReadableSpan objects.
+   * @param apiHost The host of the LangTrace API. Default is https://app.langtrace.ai/api/trace. If set a POST request will be made to this URL with an array of ReadableSpan objects.
    * See https://github.com/open-telemetry/opentelemetry-js/blob/3c8c29ac8fdd71cd1ef78d2b35c65ced81db16f4/packages/opentelemetry-sdk-trace-base/src/export/ReadableSpan.ts#L29
    */
   constructor (apiKey: string, apiHost: string, headers?: Record<string, string>) {


### PR DESCRIPTION
# Description

This change updates the ingestion URL to app.langtrace.ai

# Checklist for adding new integration:

- [ ] Defined `APIS` in constants [folder](../src/constants/instrumentation/).
- [ ] Updated `SERVICE_PROVIDERS` in [common.ts](../src/constants/common.ts)
- [ ] Created a folder under [instrumentation](../src/instrumentation/) with the name of the integration with atleast `patch.ts` and `instrumentation.ts` files.
- [ ] Added instrumentation in `allInstrumentations` in [init.ts](../src/init/init.ts) and to the `InstrumentationType` in [types.ts](../src/init/types.ts) files.
- [ ] Added examples for the new integration in the [examples](../src/examples/) folder.
- [ ] Updated [package.json](../package.json) to install new dependencies for devDependencies.
- [ ] Updated the [README.md](../README.md) of [langtrace-typescript-sdk](https://github.com/Scale3-Labs/langtrace-typescript-sdk) to include the new integration in the supported integrations table.
- [ ] Updated the [README.md](https://github.com/Scale3-Labs/langtrace?tab=readme-ov-file#supported-integrations) of Langtrace's [repository](https://github.com/Scale3-Labs/langtrace) to include the new integration in the supported integrations table.
- [ ] Added new integration page to supported integrations in [Langtrace Docs](https://github.com/Scale3-Labs/langtrace-docs)
