### PR TITLE
Fix ChromaDB Instrumentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@langtrase/typescript-sdk",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@langtrase/typescript-sdk",
-      "version": "6.1.0",
+      "version": "6.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-bedrock-runtime": "^3.670.0",
@@ -36,7 +36,7 @@
         "@qdrant/js-client-rest": "^1.9.0",
         "@typescript-eslint/eslint-plugin": "^5.62.0",
         "ai": "^3.2.29",
-        "chromadb": "^1.8.1",
+        "chromadb": "^1.9.4",
         "cohere-ai": "^7.9.3",
         "dotenv": "^16.4.5",
         "eslint": "^8.34.0",
@@ -7096,10 +7096,11 @@
       "dev": true
     },
     "node_modules/chromadb": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/chromadb/-/chromadb-1.8.1.tgz",
-      "integrity": "sha512-NpbYydbg4Uqt/9BXKgkZXn0fqpsh2Z1yjhkhKH+rcHMoq0pwI18BFSU2QU7Fk/ZypwGefW2AvqyE/3ZJIgy4QA==",
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/chromadb/-/chromadb-1.9.4.tgz",
+      "integrity": "sha512-KtBy3uvZWV5+B6tlSYxwi8YW+Dv+qBs2spffSaamLeAHLn+N4ss6xoscLWDp5J1ImfscT8NFW1lGZlTZbs8Huw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "cliui": "^8.0.1",
         "isomorphic-fetch": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@qdrant/js-client-rest": "^1.9.0",
     "@typescript-eslint/eslint-plugin": "^5.62.0",
     "ai": "^3.2.29",
-    "chromadb": "^1.8.1",
+    "chromadb": "^1.9.4",
     "cohere-ai": "^7.9.3",
     "dotenv": "^16.4.5",
     "eslint": "^8.34.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@langtrase/typescript-sdk",
-  "version": "6.2.0",
+  "version": "6.3.0",
   "description": "A typescript SDK for Langtrace",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
# Description

ChromaDB is not exporting the Collection class anymore. This fix is to make it work for versions >1.9.0

# Checklist for adding new integration:

- [ ] Defined `APIS` in constants [folder](../src/constants/instrumentation/).
- [ ] Updated `SERVICE_PROVIDERS` in [common.ts](../src/constants/common.ts)
- [ ] Created a folder under [instrumentation](../src/instrumentation/) with the name of the integration with atleast `patch.ts` and `instrumentation.ts` files.
- [ ] Added instrumentation in `allInstrumentations` in [init.ts](../src/init/init.ts) and to the `InstrumentationType` in [types.ts](../src/init/types.ts) files.
- [ ] Added examples for the new integration in the [examples](../src/examples/) folder.
- [ ] Updated [package.json](../package.json) to install new dependencies for devDependencies.
- [ ] Updated the [README.md](../README.md) of [langtrace-typescript-sdk](https://github.com/Scale3-Labs/langtrace-typescript-sdk) to include the new integration in the supported integrations table.
- [ ] Updated the [README.md](https://github.com/Scale3-Labs/langtrace?tab=readme-ov-file#supported-integrations) of Langtrace's [repository](https://github.com/Scale3-Labs/langtrace) to include the new integration in the supported integrations table.
- [ ] Added new integration page to supported integrations in [Langtrace Docs](https://github.com/Scale3-Labs/langtrace-docs)
