### PR TITLE
Ali/add support for preview vertexai

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # @langtrase/typescript-sdk
+## 6.3.2
+### Patch Changes
+
+- Add Support for preview module inside VertexAI
 
 ## 5.4.0
 

--- a/src/instrumentation/vertexai/instrumentation.ts
+++ b/src/instrumentation/vertexai/instrumentation.ts
@@ -55,6 +55,18 @@ class VertexAIInstrumentation extends InstrumentationBase<any> {
       this._unpatch(vertexai)
     }
 
+    this._wrap(vertexai.GenerativeModelPreview.prototype,
+      'generateContent',
+      (originalMethod: (...args: any[]) => any) =>
+        generateContentPatch(originalMethod, this.tracer, APIS.vertexai.GENERATE_CONTENT.METHOD, this.instrumentationVersion, name, moduleVersion)
+    )
+
+    this._wrap(vertexai.GenerativeModelPreview.prototype,
+      'generateContentStream',
+      (originalMethod: (...args: any[]) => any) =>
+        generateContentPatch(originalMethod, this.tracer, APIS.vertexai.GENERATE_CONTENT_STREAM.METHOD, this.instrumentationVersion, name, moduleVersion)
+    )
+
     this._wrap(vertexai.GenerativeModel.prototype,
       'generateContent',
       (originalMethod: (...args: any[]) => any) =>


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue to help is review the PR better and faster.

# Checklist for adding new integration:

- [ ] Defined `APIS` in constants [folder](../src/constants/instrumentation/).
- [ ] Updated `SERVICE_PROVIDERS` in [common.ts](../src/constants/common.ts)
- [ ] Created a folder under [instrumentation](../src/instrumentation/) with the name of the integration with atleast `patch.ts` and `instrumentation.ts` files.
- [ ] Added instrumentation in `allInstrumentations` in [init.ts](../src/init/init.ts) and to the `InstrumentationType` in [types.ts](../src/init/types.ts) files.
- [ ] Added examples for the new integration in the [examples](../src/examples/) folder.
- [ ] Updated [package.json](../package.json) to install new dependencies for devDependencies.
- [ ] Updated the [README.md](../README.md) of [langtrace-typescript-sdk](https://github.com/Scale3-Labs/langtrace-typescript-sdk) to include the new integration in the supported integrations table.
- [ ] Updated the [README.md](https://github.com/Scale3-Labs/langtrace?tab=readme-ov-file#supported-integrations) of Langtrace's [repository](https://github.com/Scale3-Labs/langtrace) to include the new integration in the supported integrations table.
- [ ] Added new integration page to supported integrations in [Langtrace Docs](https://github.com/Scale3-Labs/langtrace-docs)
